### PR TITLE
Patch Browser update and fix

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -182,6 +182,7 @@ Jv880_juceAudioProcessor::Jv880_juceAudioProcessor()
 
     // total count
     totalPatchesExp += nPatches;
+    totalPatchesExp += nDrumkits;
   }
 
   loaded = true;

--- a/Source/ui/PatchBrowser.h
+++ b/Source/ui/PatchBrowser.h
@@ -40,7 +40,7 @@ static const char *groupNames[] = {
 };
 
 const int columns = 6;
-const int rowPerColumn = 43;
+const int rowPerColumn = 44;
 
 //==============================================================================
 /*


### PR DESCRIPTION
Fixed the patch loading issue for the last ROM loaded in an instance by adding the drum kits to the number of programs. More trivially, also added an extra row for patches due to one entry too many for some ROM's.