### PR TITLE
Fixes for RD-500 missing update

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -109,9 +109,11 @@ Jv880_juceAudioProcessor::Jv880_juceAudioProcessor()
   currentPatchI++;
 
   for (int i = 0; i < NUM_EXPS; i++) {
-    if (romInfos[i + 6].loaded == false)
-        continue;
     patchInfoPerGroup.push_back(std::vector<PatchInfo *>());
+      if (romInfos[i + 6].loaded == false)
+          continue;
+      else if (i == 0 && romInfos[5].loaded == false)
+          continue;
 
     expansionsDescr[i] = loadedRoms[i + 6];
 
@@ -208,9 +210,9 @@ bool Jv880_juceAudioProcessor::isMidiEffect() const { return false; }
 double Jv880_juceAudioProcessor::getTailLengthSeconds() const { return 0.0; }
 
 int Jv880_juceAudioProcessor::getNumPrograms() {
-  return 64                // internal
-         + 64              // bank A
-         + 64              // bank B
+  return 65                // internal
+         + 65              // bank A
+         + 65              // bank B
          + totalPatchesExp // expansions
       ;
 }

--- a/Source/ui/PatchBrowser.h
+++ b/Source/ui/PatchBrowser.h
@@ -98,7 +98,7 @@ private:
     }
 
     int getNumRows() override {
-      if (!parent->audioProcessor.loaded || !(romInfos[std::max(groupI, 1) + romCountRequired].loaded)) {
+      if (!parent->audioProcessor.loaded || (groupI <= 1 && romInfos[std::max(groupI, 0) + romCountRequired + 5].loaded == false) || (groupI > 0 && romInfos[std::max(groupI, 0) + romCountRequired + 1].loaded == false)) {
         return 0;
       }
 


### PR DESCRIPTION
Fixed the crashing of the plugin for missing RD-500 ROM's specifically.

Also fixed the patch count for internal ROM presets to include drum kits.