### PR TITLE
Implement leaner sysex sending for common parameters

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -391,9 +391,12 @@ void Jv880_juceAudioProcessor::sendSysexParamChange(uint32_t address,
   data[2] = (address >> 7) & 127;  // address
   data[3] = (address >> 0) & 127;  // address LSB
   data[4] = value;                 // data
+
   uint32_t checksum = 0;
+
   for (size_t i = 0; i < 5; i++) {
     checksum += data[i];
+
     if (checksum >= 128) {
       checksum -= 128;
     }
@@ -405,10 +408,13 @@ void Jv880_juceAudioProcessor::sendSysexParamChange(uint32_t address,
   buf[2] = 0x10; // unit number
   buf[3] = 0x46;
   buf[4] = 0x12; // command
+
   checksum = 128 - checksum;
+
   for (size_t i = 0; i < 5; i++) {
     buf[i + 5] = data[i];
   }
+
   buf[10] = checksum;
   buf[11] = 0xf7;
 

--- a/Source/ui/EditCommonTab.cpp
+++ b/Source/ui/EditCommonTab.cpp
@@ -10,7 +10,6 @@
 
 #include <JuceHeader.h>
 #include "EditCommonTab.h"
-#include "../dataStructures.h"
 
 //==============================================================================
 EditCommonTab::EditCommonTab(Jv880_juceAudioProcessor& p) : audioProcessor (p)
@@ -20,19 +19,16 @@ EditCommonTab::EditCommonTab(Jv880_juceAudioProcessor& p) : audioProcessor (p)
     patchNameEditor.setInputRestrictions(MAX_PATCH_NAME_CHARS,
                                          " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-*/#!,.");
     addAndMakeVisible(patchNameLabel);
-    patchNameLabel.setText("Patch Name", juce::dontSendNotification);
     patchNameLabel.attachToComponent(&patchNameEditor, true);
 
     addAndMakeVisible(velocitySwitchToggle);
     velocitySwitchToggle.addListener(this);
-    velocitySwitchToggle.setButtonText ("Velocity Switch");
 
     addAndMakeVisible(reverbTypeLabel);
-    reverbTypeLabel.setText("Reverb", juce::dontSendNotification);
     reverbTypeLabel.attachToComponent(&reverbTypeComboBox, true);
+
     addAndMakeVisible(reverbTypeComboBox);
     reverbTypeComboBox.addListener(this);
-    reverbTypeComboBox.setScrollWheelEnabled (true);
     reverbTypeComboBox.addItem("Room 1", 1);
     reverbTypeComboBox.addItem("Room 2", 2);
     reverbTypeComboBox.addItem("Stage 1", 3);
@@ -43,159 +39,125 @@ EditCommonTab::EditCommonTab(Jv880_juceAudioProcessor& p) : audioProcessor (p)
     reverbTypeComboBox.addItem("Pan Delay", 8);
 
     addAndMakeVisible(reverbLevelSlider);
-    reverbLevelSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    reverbLevelSlider.setRange (0, 127, 1);
     reverbLevelSlider.addListener(this);
+
     addAndMakeVisible(reverbLevelLabel);
-    reverbLevelLabel.setText("Level", juce::dontSendNotification);
     reverbLevelLabel.attachToComponent(&reverbLevelSlider, true);
 
     addAndMakeVisible(reverbTimeSlider);
-    reverbTimeSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    reverbTimeSlider.setRange (0, 127, 1);
     reverbTimeSlider.addListener(this);
+
     addAndMakeVisible(reverbTimeLabel);
-    reverbTimeLabel.setText("Time", juce::dontSendNotification);
     reverbTimeLabel.attachToComponent(&reverbTimeSlider, true);
 
     addAndMakeVisible(delayFeedbackSlider);
-    delayFeedbackSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    delayFeedbackSlider.setRange (0, 127, 1);
     delayFeedbackSlider.addListener(this);
+
     addAndMakeVisible(delayFeedbackLabel);
-    delayFeedbackLabel.setText("Feedback", juce::dontSendNotification);
     delayFeedbackLabel.attachToComponent(&delayFeedbackSlider, true);
 
     addAndMakeVisible(chorusTypeLabel);
-    chorusTypeLabel.setText("Chorus", juce::dontSendNotification);
     chorusTypeLabel.attachToComponent(&chorusTypeComboBox, true);
+
     addAndMakeVisible(chorusTypeComboBox);
     chorusTypeComboBox.addListener(this);
-    chorusTypeComboBox.setScrollWheelEnabled (true);
     chorusTypeComboBox.addItem("Type 1", 1);
     chorusTypeComboBox.addItem("Type 2", 2);
     chorusTypeComboBox.addItem("Type 3", 3);
     
     addAndMakeVisible(chorusLevelSlider);
-    chorusLevelSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    chorusLevelSlider.setRange (0, 127, 1);
     chorusLevelSlider.addListener(this);
+
     addAndMakeVisible(chorusLevelLabel);
-    chorusLevelLabel.setText("Level", juce::dontSendNotification);
     chorusLevelLabel.attachToComponent(&chorusLevelSlider, true);
     
     addAndMakeVisible(chorusDepthSlider);
-    chorusDepthSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    chorusDepthSlider.setRange (0, 127, 1);
     chorusDepthSlider.addListener(this);
+
     addAndMakeVisible(chorusDepthLabel);
-    chorusDepthLabel.setText("Depth", juce::dontSendNotification);
     chorusDepthLabel.attachToComponent(&chorusDepthSlider, true);
     
     addAndMakeVisible(chorusRateSlider);
-    chorusRateSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    chorusRateSlider.setRange (0, 127, 1);
     chorusRateSlider.addListener(this);
-    addAndMakeVisible(chorusRateSlider);
-    chorusRateLabel.setText("Rate", juce::dontSendNotification);
+
+    addAndMakeVisible(chorusRateLabel);
     chorusRateLabel.attachToComponent(&chorusRateSlider, true);
     
     addAndMakeVisible(chorusFeedbackSlider);
-    chorusFeedbackSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    chorusFeedbackSlider.setRange (0, 127, 1);
     chorusFeedbackSlider.addListener(this);
+
     addAndMakeVisible(chorusFeedbackLabel);
-    chorusFeedbackLabel.setText("Feedback", juce::dontSendNotification);
     chorusFeedbackLabel.attachToComponent(&chorusFeedbackSlider, true);
 
     addAndMakeVisible(chorusOutputLabel);
-    chorusOutputLabel.setText("Output", juce::dontSendNotification);
     chorusOutputLabel.attachToComponent(&chorusOutputComboBox, true);
+
     addAndMakeVisible(chorusOutputComboBox);
     chorusOutputComboBox.addListener(this);
-    chorusOutputComboBox.setScrollWheelEnabled (true);
     chorusOutputComboBox.addItem("Mix", 1);
     chorusOutputComboBox.addItem("Reverb", 2);
     
     addAndMakeVisible(analogFeelSlider);
-    analogFeelSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    analogFeelSlider.setRange (0, 127, 1);
     analogFeelSlider.addListener(this);
+
     addAndMakeVisible(analogFeelLabel);
-    analogFeelLabel.setText("Analog Feel", juce::dontSendNotification);
     analogFeelLabel.attachToComponent(&analogFeelSlider, true);
     
     addAndMakeVisible(levelSlider);
-    levelSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    levelSlider.setRange (0, 127, 1);
     levelSlider.addListener(this);
+
     addAndMakeVisible(levelLabel);
-    levelLabel.setText("Level", juce::dontSendNotification);
     levelLabel.attachToComponent(&levelSlider, true);
     
     addAndMakeVisible(panSlider);
-    panSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    panSlider.setRange (0, 127, 1);
     panSlider.addListener(this);
+
     addAndMakeVisible(panLabel);
-    panLabel.setText("Pan", juce::dontSendNotification);
     panLabel.attachToComponent(&panSlider, true);
     
     addAndMakeVisible(bendRangeDownSlider);
-    bendRangeDownSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    bendRangeDownSlider.setRange (-48, 0, 1);
     bendRangeDownSlider.addListener(this);
 
     addAndMakeVisible(bendRangeLabel);
-    bendRangeLabel.setText("Bend Range", juce::dontSendNotification);
     bendRangeLabel.attachToComponent(&bendRangeDownSlider, true);
     
     addAndMakeVisible(bendRangeUpSlider);
-    bendRangeUpSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    bendRangeUpSlider.setRange (0, 12, 1);
     bendRangeUpSlider.addListener(this);
 
     addAndMakeVisible(keyAssignLabel);
-    keyAssignLabel.setText("Key Assign", juce::dontSendNotification);
     keyAssignLabel.attachToComponent(&keyAssignComboBox, true);
+
     addAndMakeVisible(keyAssignComboBox);
     keyAssignComboBox.addListener(this);
-    keyAssignComboBox.setScrollWheelEnabled (true);
     keyAssignComboBox.addItem("Poly", 1);
     keyAssignComboBox.addItem("Solo", 2);
 
     addAndMakeVisible(soloLegatoToggle);
     soloLegatoToggle.addListener(this);
-    soloLegatoToggle.setButtonText ("Legato");
 
     addAndMakeVisible(portamentoToggle);
     portamentoToggle.addListener(this);
-    portamentoToggle.setButtonText ("Portamento");
 
     addAndMakeVisible(portamentoModeLabel);
-    portamentoModeLabel.setText("Mode", juce::dontSendNotification);
     portamentoModeLabel.attachToComponent(&portamentoModeComboBox, true);
+
     addAndMakeVisible(portamentoModeComboBox);
     portamentoModeComboBox.addListener(this);
-    portamentoModeComboBox.setScrollWheelEnabled (true);
     portamentoModeComboBox.addItem("Legato", 1);
     portamentoModeComboBox.addItem("Normal", 2);
 
     addAndMakeVisible(portamentoTypeLabel);
-    portamentoTypeLabel.setText("Type", juce::dontSendNotification);
     portamentoTypeLabel.attachToComponent(&portamentoTypeComboBox, true);
+
     addAndMakeVisible(portamentoTypeComboBox);
     portamentoTypeComboBox.addListener(this);
-    portamentoTypeComboBox.setScrollWheelEnabled (true);
     portamentoTypeComboBox.addItem("Time", 1);
     portamentoTypeComboBox.addItem("Rate", 2);
     
     addAndMakeVisible(portamentoTimeSlider);
-    portamentoTimeSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBar);
-    portamentoTimeSlider.setRange (0, 127, 1);
     portamentoTimeSlider.addListener(this);
+
     addAndMakeVisible(portamentoTimeLabel);
-    portamentoTimeLabel.setText("Time", juce::dontSendNotification);
     portamentoTimeLabel.attachToComponent(&portamentoTimeSlider, true);
 }
 
@@ -279,77 +241,189 @@ void EditCommonTab::resized()
     portamentoTimeSlider   .setBounds(sliderLeft2, top + height * 8 + vMargin * 4, width, height);
 }
 
-void EditCommonTab::sliderValueChanged (juce::Slider* slider)
+void EditCommonTab::sliderValueChanged(juce::Slider* slider)
 {
-    if (slider == &reverbLevelSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &reverbTimeSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &delayFeedbackSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &chorusLevelSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &chorusDepthSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &chorusRateSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &chorusFeedbackSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &analogFeelSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &levelSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &panSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &bendRangeDownSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &bendRangeUpSlider)
-        sendSysexPatchCommonChange();
-    else if (slider == &portamentoTimeSlider)
-        sendSysexPatchCommonChange();
+    uint32_t id = 0xFFFFFFF;
+
+    if (auto i = dynamic_cast<Slider*>(slider))
+    {
+        id = i->getID();
+    }
+
+    Patch* patch = (Patch*)audioProcessor.status.patch;
+
+    switch (id)
+    {
+    case ReverbLevel:
+        sendSysexPatchCommonParamChange(0x0e, reverbLevelSlider.getValue());
+        patch->reverbLevel = uint8_t(reverbLevelSlider.getValue());
+        break;
+    case ReverbTime:
+        sendSysexPatchCommonParamChange(0x0f, reverbTimeSlider.getValue());
+        patch->reverbTime = uint8_t(reverbTimeSlider.getValue());
+        break;
+    case DelayFeedback:
+        sendSysexPatchCommonParamChange(0x10, delayFeedbackSlider.getValue());
+        patch->reverbFeedback = uint8_t(delayFeedbackSlider.getValue());
+        break;
+    case ChorusLevel:
+        sendSysexPatchCommonParamChange(0x12, chorusLevelSlider.getValue());
+        patch->chorusLevel = uint8_t(chorusLevelSlider.getValue()
+                                     + (chorusOutputComboBox.getSelectedItemIndex() << 7));
+        break;
+    case ChorusDepth:
+        sendSysexPatchCommonParamChange(0x13, chorusDepthSlider.getValue());
+        patch->chorusDepth = uint8_t(chorusDepthSlider.getValue());
+        break;
+    case ChorusRate:
+        sendSysexPatchCommonParamChange(0x14, chorusRateSlider.getValue());
+        patch->chorusRate = uint8_t(chorusRateSlider.getValue());
+        break;
+    case ChorusFeedback:
+        sendSysexPatchCommonParamChange(0x15, chorusFeedbackSlider.getValue());
+        patch->chorusFeedback = uint8_t(chorusFeedbackSlider.getValue());
+        break;
+    case AnalogFeel:
+        sendSysexPatchCommonParamChange(0x17, analogFeelSlider.getValue());
+        patch->analogFeel = uint8_t(analogFeelSlider.getValue());
+        break;
+    case Level:
+        sendSysexPatchCommonParamChange(0x18, levelSlider.getValue());
+        patch->level = uint8_t(levelSlider.getValue());
+        break;
+    case Pan:
+        sendSysexPatchCommonParamChange(0x19, panSlider.getValue());
+        patch->pan = uint8_t(panSlider.getValue());
+        break;
+    case BendRangeDown:
+        sendSysexPatchCommonParamChange(0x1a, bendRangeDownSlider.getValue());
+        patch->bendRange = uint8_t(bendRangeDownSlider.getValue() + 64);
+        break;
+    case BendRangeUp:
+        sendSysexPatchCommonParamChange(0x1b, bendRangeUpSlider.getValue());
+        patch->flags = uint8_t(bendRangeUpSlider.getValue()
+                               + (portamentoModeComboBox.getSelectedItemIndex() << 4)
+                               + (soloLegatoToggle.getToggleState() << 5)
+                               + (portamentoToggle.getToggleState() << 6)
+                               + (keyAssignComboBox.getSelectedItemIndex() << 7));
+        break;
+    case PortamentoTime:
+        sendSysexPatchCommonParamChange(0x21, portamentoTimeSlider.getValue());
+        patch->portamentoTime = uint8_t(portamentoTimeSlider.getValue()
+                                        + (portamentoTypeComboBox.getSelectedItemIndex() << 7));
+        break;
+    default:
+        break;
+    }
 }
 
-void EditCommonTab::buttonClicked (juce::Button* button)
+void EditCommonTab::buttonClicked(juce::Button* button)
 {
-    if (button == &velocitySwitchToggle)
-        sendSysexPatchCommonChange();
-    else if (button == &soloLegatoToggle)
-        sendSysexPatchCommonChange();
-    else if (button == &portamentoToggle)
-        sendSysexPatchCommonChange();
+    uint32_t id = 0xFFFFFFF;
+
+    if (auto i = dynamic_cast<Button*>(button))
+    {
+        id = i->getID();
+    }
+
+    Patch* patch = (Patch*)audioProcessor.status.patch;
+
+    switch (id)
+    {
+    case VelocitySwitch:
+        sendSysexPatchCommonParamChange(0x0c, velocitySwitchToggle.getToggleStateValue() == 1);
+        patch->recChorConfig = uint8_t(reverbTypeComboBox.getSelectedItemIndex()
+                                       + (chorusTypeComboBox.getSelectedItemIndex() << 4)
+                                       + (velocitySwitchToggle.getToggleState() << 7));
+        break;
+    case SoloLegato:
+        sendSysexPatchCommonParamChange(0x1d, soloLegatoToggle.getToggleStateValue() == 1);
+        patch->flags = uint8_t(bendRangeUpSlider.getValue()
+                               + (portamentoModeComboBox.getSelectedItemIndex() << 4)
+                               + (soloLegatoToggle.getToggleState() << 5)
+                               + (portamentoToggle.getToggleState() << 6)
+                               + (keyAssignComboBox.getSelectedItemIndex() << 7));
+        break;
+    case Portamento:
+        sendSysexPatchCommonParamChange(0x1e, portamentoToggle.getToggleStateValue() == 1);
+        patch->flags = uint8_t(bendRangeUpSlider.getValue()
+                               + (portamentoModeComboBox.getSelectedItemIndex() << 4)
+                               + (soloLegatoToggle.getToggleState() << 5)
+                               + (portamentoToggle.getToggleState() << 6)
+                               + (keyAssignComboBox.getSelectedItemIndex() << 7));
+        break;
+    default:
+        break;
+    }
 }
 
-void EditCommonTab::buttonStateChanged (juce::Button* button)
+void EditCommonTab::comboBoxChanged(juce::ComboBox* comboBox)
 {
-}
+    uint32_t id = 0xFFFFFFF;
 
-void EditCommonTab::comboBoxChanged (juce::ComboBox* comboBox)
-{
-    if (comboBox == &reverbTypeComboBox)
-        sendSysexPatchCommonChange();
-    else if (comboBox == &chorusTypeComboBox)
-        sendSysexPatchCommonChange();
-    else if (comboBox == &chorusOutputComboBox)
-        sendSysexPatchCommonChange();
-    else if (comboBox == &keyAssignComboBox)
-        sendSysexPatchCommonChange();
-    else if (comboBox == &portamentoModeComboBox)
-        sendSysexPatchCommonChange();
-    else if (comboBox == &portamentoTypeComboBox)
-        sendSysexPatchCommonChange();
+    if (auto i = dynamic_cast<Menu*>(comboBox))
+    {
+        id = i->getID();
+    }
+
+    Patch* patch = (Patch*) audioProcessor.status.patch;
+    
+    switch (id)
+    {
+    case ReverbType:
+        sendSysexPatchCommonParamChange(0x0d, reverbTypeComboBox.getSelectedItemIndex());
+        patch->recChorConfig = uint8_t(reverbTypeComboBox.getSelectedItemIndex()
+                                       + (chorusTypeComboBox.getSelectedItemIndex() << 4)
+                                       + (velocitySwitchToggle.getToggleState() << 7));
+        break;
+    case ChorusType:
+        sendSysexPatchCommonParamChange(0x11, chorusTypeComboBox.getSelectedItemIndex());
+        patch->recChorConfig = uint8_t(reverbTypeComboBox.getSelectedItemIndex()
+                                       + (chorusTypeComboBox.getSelectedItemIndex() << 4)
+                                       + (velocitySwitchToggle.getToggleState() << 7));
+        break;
+    case ChorusOutput:
+        sendSysexPatchCommonParamChange(0x16, chorusOutputComboBox.getSelectedItemIndex());
+        patch->chorusLevel = uint8_t(chorusLevelSlider.getValue()
+                                     + (chorusOutputComboBox.getSelectedItemIndex() << 7));
+        break;
+    case KeyAssign:
+        sendSysexPatchCommonParamChange(0x1c, keyAssignComboBox.getSelectedItemIndex());
+        patch->flags = uint8_t(bendRangeUpSlider.getValue()
+                               + (portamentoModeComboBox.getSelectedItemIndex() << 4)
+                               + (soloLegatoToggle.getToggleState() << 5)
+                               + (portamentoToggle.getToggleState() << 6)
+                               + (keyAssignComboBox.getSelectedItemIndex() << 7));
+        break;
+    case PortamentoMode:
+        sendSysexPatchCommonParamChange(0x1f, portamentoModeComboBox.getSelectedItemIndex());
+        patch->flags = uint8_t(bendRangeUpSlider.getValue()
+                               + (portamentoModeComboBox.getSelectedItemIndex() << 4)
+                               + (soloLegatoToggle.getToggleState() << 5)
+                               + (portamentoToggle.getToggleState() << 6)
+                               + (keyAssignComboBox.getSelectedItemIndex() << 7));
+        break;
+    case PortamentoType:
+        sendSysexPatchCommonParamChange(0x20, portamentoTypeComboBox.getSelectedItemIndex());
+        patch->portamentoTime = uint8_t(portamentoTimeSlider.getValue()
+                                        + (portamentoTypeComboBox.getSelectedItemIndex() << 7));
+        break;
+    default:
+        break;
+    }
 }
 
 void EditCommonTab::textEditorTextChanged (juce::TextEditor& textEditor)
 {
     if (&textEditor == &patchNameEditor)
-        sendSysexPatchCommonChange();
+        sendSysexPatchNameChange();
 }
 
-void EditCommonTab::sendSysexPatchCommonChange()
+void EditCommonTab::sendSysexPatchNameChange()
 {
-    Patch* patch = (Patch*) audioProcessor.status.patch;
-    
-    uint8_t buf[45];
+    auto patch = (Patch*) audioProcessor.status.patch;
+
+    uint8_t buf[24];
 
     buf[0] = 0xf0;
     buf[1] = 0x41;
@@ -363,61 +437,7 @@ void EditCommonTab::sendSysexPatchCommonChange()
 
     for (int i = 0; i < juce::jmin(MAX_PATCH_NAME_CHARS, patchNameEditor.getText().length()); i++)
     {
-        buf[i + 9] = patchNameEditor.getText()[i];
-    }
-
-    if (patchNameEditor.getText().length() < MAX_PATCH_NAME_CHARS)
-    {
-        for (int i = patchNameEditor.getText().length(); i < MAX_PATCH_NAME_CHARS; i++)
-        {
-            buf[i + 9] = 0x20;
-        }
-    }
-
-    buf[21] = velocitySwitchToggle.getToggleStateValue() == 1 ? 1U : 0U;
-    buf[22] = reverbTypeComboBox.getSelectedItemIndex();
-    buf[23] = uint8_t(reverbLevelSlider.getValue());
-    buf[24] = uint8_t(reverbTimeSlider.getValue());
-    buf[25] = uint8_t(delayFeedbackSlider.getValue());
-    buf[26] = chorusTypeComboBox.getSelectedItemIndex();
-    buf[27] = uint8_t(chorusLevelSlider.getValue());
-    buf[28] = uint8_t(chorusDepthSlider.getValue());
-    buf[29] = uint8_t(chorusRateSlider.getValue());
-    buf[30] = uint8_t(chorusFeedbackSlider.getValue());
-    buf[31] = chorusOutputComboBox.getSelectedItemIndex();
-    buf[32] = uint8_t(analogFeelSlider.getValue());
-    buf[33] = uint8_t(levelSlider.getValue());
-    buf[34] = uint8_t(panSlider.getValue());
-    buf[35] = uint8_t(bendRangeDownSlider.getValue() + 64);
-    buf[36] = uint8_t(bendRangeUpSlider.getValue());
-    buf[37] = keyAssignComboBox.getSelectedItemIndex();
-    buf[38] = soloLegatoToggle.getToggleStateValue() == 1 ? 1U : 0U;
-    buf[39] = portamentoToggle.getToggleStateValue() == 1 ? 1U : 0U;
-    buf[40] = portamentoModeComboBox.getSelectedItemIndex();
-    buf[41] = portamentoTypeComboBox.getSelectedItemIndex();
-    buf[42] = uint8_t(portamentoTimeSlider.getValue());
-    
-    uint32_t checksum = 0;
-    
-    for (size_t i = 5; i < 43; i++)
-    {
-        checksum += buf[i];
-
-        if (checksum >= 128)
-            checksum -= 128;
-    }
-    
-    checksum = 128 - checksum;
-    
-    buf[43] = checksum;
-    buf[44] = 0xf7;
-
-    audioProcessor.mcuLock.enter();
-    audioProcessor.mcu->postMidiSC55(buf, 45);
-    audioProcessor.mcuLock.exit();
-    
-    for (int i = 0; i < juce::jmin(MAX_PATCH_NAME_CHARS, patchNameEditor.getText().length()); i++)
-    {
+        buf[i + 9]     = patchNameEditor.getText()[i];
         patch->name[i] = patchNameEditor.getText()[i];
     }
 
@@ -425,30 +445,62 @@ void EditCommonTab::sendSysexPatchCommonChange()
     {
         for (int i = patchNameEditor.getText().length(); i < MAX_PATCH_NAME_CHARS; i++)
         {
+            buf[i + 9]     = 0x20;
             patch->name[i] = 0x20;
         }
     }
 
-    patch->recChorConfig = uint8_t(reverbTypeComboBox.getSelectedItemIndex()
-                                   + (chorusTypeComboBox.getSelectedItemIndex() << 4)
-                                   + (velocitySwitchToggle.getToggleState() << 7));
-    patch->reverbLevel = uint8_t(reverbLevelSlider.getValue());
-    patch->reverbTime = uint8_t(reverbTimeSlider.getValue());
-    patch->reverbFeedback = uint8_t(delayFeedbackSlider.getValue());
-    patch->chorusLevel = uint8_t(chorusLevelSlider.getValue()
-                                 + (chorusOutputComboBox.getSelectedItemIndex() << 7));
-    patch->chorusDepth = uint8_t(chorusDepthSlider.getValue());
-    patch->chorusRate = uint8_t(chorusRateSlider.getValue());
-    patch->chorusFeedback = uint8_t(chorusFeedbackSlider.getValue());
-    patch->analogFeel = uint8_t(analogFeelSlider.getValue());
-    patch->level = uint8_t(levelSlider.getValue());
-    patch->pan = uint8_t(panSlider.getValue());
-    patch->bendRange = uint8_t(bendRangeDownSlider.getValue() + 64);
-    patch->flags = uint8_t(bendRangeUpSlider.getValue()
-                           + (portamentoModeComboBox.getSelectedItemIndex() << 4)
-                           + (soloLegatoToggle.getToggleState() << 5)
-                           + (portamentoToggle.getToggleState() << 6)
-                           + (keyAssignComboBox.getSelectedItemIndex() << 7));
-    patch->portamentoTime = uint8_t(portamentoTimeSlider.getValue()
-                                    + (portamentoTypeComboBox.getSelectedItemIndex() << 7));
+    uint32_t checksum = 0;
+
+    for (size_t i = 5; i < 21; i++)
+    {
+        checksum += buf[i];
+
+        if (checksum >= 128)
+            checksum -= 128;
+    }
+
+    checksum = 128 - checksum;
+
+    buf[22] = checksum;
+    buf[23] = 0xf7;
+
+    audioProcessor.mcuLock.enter();
+    audioProcessor.mcu->postMidiSC55(buf, 24);
+    audioProcessor.mcuLock.exit();
+}
+
+void EditCommonTab::sendSysexPatchCommonParamChange(const uint8_t address, const uint8_t value)
+{
+    uint8_t buf[12];
+
+    buf[0] = 0xf0;
+    buf[1] = 0x41;
+    buf[2] = 0x10; // unit number
+    buf[3] = 0x46;
+    buf[4] = 0x12; // command
+    buf[5] = 0x00;
+    buf[6] = 0x08;
+    buf[7] = 0x20;
+    buf[8] = address;
+    buf[9] = value;
+
+    uint32_t checksum = 0;
+
+    for (size_t i = 5; i < 10; i++)
+    {
+        checksum += buf[i];
+
+        if (checksum >= 128)
+           checksum -= 128;
+    }
+
+    checksum = 128 - checksum;
+
+    buf[10] = checksum;
+    buf[11] = 0xf7;
+
+    audioProcessor.mcuLock.enter();
+    audioProcessor.mcu->postMidiSC55(buf, 12);
+    audioProcessor.mcuLock.exit();
 }

--- a/Source/ui/EditCommonTab.h
+++ b/Source/ui/EditCommonTab.h
@@ -10,8 +10,15 @@
 
 #pragma once
 
-#include "../PluginProcessor.h"
 #include <JuceHeader.h>
+
+#include "../PluginProcessor.h"
+#include "../dataStructures.h"
+
+#include "widgets/Button.h"
+#include "widgets/Menu.h"
+#include "widgets/Slider.h"
+#include "widgets/TextEdit.h"
 
 constexpr int MAX_PATCH_NAME_CHARS = 12;
 
@@ -19,7 +26,8 @@ class EditCommonTab : public juce::Component,
                       public juce::Slider::Listener,
                       public juce::Button::Listener,
                       public juce::ComboBox::Listener,
-                      public juce::TextEditor::Listener {
+                      public juce::TextEditor::Listener
+{
 public:
   EditCommonTab(Jv880_juceAudioProcessor &);
   ~EditCommonTab() override;
@@ -28,62 +36,94 @@ public:
 
   void visibilityChanged() override;
   void resized() override;
-  void sliderValueChanged(juce::Slider *) override;
+  void sliderValueChanged(juce::Slider*) override;
   void buttonClicked(juce::Button *) override;
-  void buttonStateChanged(juce::Button *) override;
+  void buttonStateChanged(juce::Button*) override {};
   void comboBoxChanged(juce::ComboBox *) override;
   void textEditorTextChanged(juce::TextEditor &) override;
-  void sendSysexPatchCommonChange();
+
+  void sendSysexPatchNameChange();
+  void sendSysexPatchCommonParamChange(const uint8_t address, const uint8_t value);
 
 private:
+  enum EditCommonWidgets
+  {
+      PatchName           = 100U,
+      VelocitySwitch      = 101U,
+
+      ReverbType          = 110U,
+      ReverbLevel         = 111U,
+      ReverbTime          = 112U,
+      DelayFeedback       = 113U,
+
+      ChorusType          = 120U,
+      ChorusLevel         = 121U,
+      ChorusDepth         = 122U,
+      ChorusRate          = 123U,
+      ChorusFeedback      = 124U,
+      ChorusOutput        = 125U,
+
+      AnalogFeel          = 130U,
+      Level               = 131U,
+      Pan                 = 132U,
+      
+      BendRangeDown       = 140U,
+      BendRangeUp         = 141U,
+      KeyAssign           = 142U,
+      SoloLegato          = 143U,
+      Portamento          = 144U,
+      PortamentoMode      = 145U,
+      PortamentoType      = 146U,
+      PortamentoTime      = 147U,
+  };
   Jv880_juceAudioProcessor &audioProcessor;
 
-  juce::TextEditor patchNameEditor;
-  juce::Label patchNameLabel;
-  juce::ToggleButton velocitySwitchToggle;
+  juce::Label patchNameLabel{ "", "Patch Name" };
+  TextEdit patchNameEditor{ PatchName };
+  Button velocitySwitchToggle{ VelocitySwitch, "Velocity Switch" };
 
-  juce::Label reverbTypeLabel;
-  juce::ComboBox reverbTypeComboBox;
-  juce::Slider reverbLevelSlider;
-  juce::Label reverbLevelLabel;
-  juce::Slider reverbTimeSlider;
-  juce::Label reverbTimeLabel;
-  juce::Slider delayFeedbackSlider;
-  juce::Label delayFeedbackLabel;
+  juce::Label reverbTypeLabel{ "", "Reverb" };
+  juce::Label reverbLevelLabel{ "", "Level" };
+  juce::Label reverbTimeLabel{ "", "Time" };
+  juce::Label delayFeedbackLabel{ "", "Feedback" };
+  Menu reverbTypeComboBox{ ReverbType };
+  Slider reverbLevelSlider{ ReverbLevel, 0, 127, 1 };
+  Slider reverbTimeSlider{ ReverbTime, 0, 127, 1 };
+  Slider delayFeedbackSlider{ DelayFeedback, 0, 127, 1 };;
 
-  juce::Label chorusTypeLabel;
-  juce::ComboBox chorusTypeComboBox;
-  juce::Slider chorusLevelSlider;
-  juce::Label chorusLevelLabel;
-  juce::Slider chorusDepthSlider;
-  juce::Label chorusDepthLabel;
-  juce::Slider chorusRateSlider;
-  juce::Label chorusRateLabel;
-  juce::Slider chorusFeedbackSlider;
-  juce::Label chorusFeedbackLabel;
-  juce::Label chorusOutputLabel;
-  juce::ComboBox chorusOutputComboBox;
+  juce::Label chorusTypeLabel{ "", "Chorus" };
+  juce::Label chorusLevelLabel{ "", "Level" };
+  juce::Label chorusDepthLabel{ "", "Depth" };
+  juce::Label chorusRateLabel{ "", "Rate" };
+  juce::Label chorusFeedbackLabel{ "", "Feedback" };
+  juce::Label chorusOutputLabel{ "", "Output" };
+  Menu chorusTypeComboBox{ ChorusType };
+  Slider chorusLevelSlider{ ChorusLevel, 0, 127, 1 };
+  Slider chorusDepthSlider{ ChorusDepth, 0, 127, 1 };
+  Slider chorusRateSlider{ ChorusRate, 0, 127, 1 };
+  Slider chorusFeedbackSlider{ ChorusFeedback, 0, 127, 1 };
+  Menu chorusOutputComboBox{ ChorusOutput };
 
-  juce::Slider analogFeelSlider;
-  juce::Label analogFeelLabel;
-  juce::Slider levelSlider;
-  juce::Label levelLabel;
-  juce::Slider panSlider;
-  juce::Label panLabel;
+  juce::Label analogFeelLabel{ "", "Analog Feel" };
+  juce::Label levelLabel{ "", "Level" };
+  juce::Label panLabel{ "", "Pan" };
+  Slider analogFeelSlider{ AnalogFeel, 0, 127, 1 };
+  Slider levelSlider{ Level, 0, 127, 1 };
+  Slider panSlider{ Pan, 0, 127, 1 };
 
-  juce::Label bendRangeLabel;
-  juce::Slider bendRangeDownSlider;
-  juce::Slider bendRangeUpSlider;
-  juce::Label keyAssignLabel;
-  juce::ComboBox keyAssignComboBox;
-  juce::ToggleButton soloLegatoToggle;
-  juce::ToggleButton portamentoToggle;
-  juce::Label portamentoModeLabel;
-  juce::ComboBox portamentoModeComboBox;
-  juce::Label portamentoTypeLabel;
-  juce::ComboBox portamentoTypeComboBox;
-  juce::Slider portamentoTimeSlider;
-  juce::Label portamentoTimeLabel;
+  juce::Label bendRangeLabel{ "", "Bend Range" };
+  juce::Label keyAssignLabel{ "", "Key Assign" };
+  juce::Label portamentoModeLabel{ "", "Mode" };
+  juce::Label portamentoTypeLabel{ "", "Type" };
+  juce::Label portamentoTimeLabel{ "", "Time" };
+  Slider bendRangeDownSlider{ BendRangeDown, -48, 0, 1 };
+  Slider bendRangeUpSlider{ BendRangeUp, 0, 12, 1 };
+  Menu keyAssignComboBox{ KeyAssign };
+  Button soloLegatoToggle{ SoloLegato, "Legato" };
+  Button portamentoToggle{ Portamento, "Portamento" };
+  Menu portamentoModeComboBox{ PortamentoMode };
+  Menu portamentoTypeComboBox{ PortamentoType };
+  Slider portamentoTimeSlider{ PortamentoTime, 0, 127, 1 };
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EditCommonTab)
 };

--- a/Source/ui/EditToneTab.cpp
+++ b/Source/ui/EditToneTab.cpp
@@ -1098,12 +1098,14 @@ void EditToneTab::comboBoxChanged(juce::ComboBox* button)
 void EditToneTab::sendSysexPatchToneChange1Byte(uint8_t address, uint8_t value)
 {
     uint8_t data[5];
-    data[0] = 0x00; // address MSB
-    data[1] = 0x08; // address
+    data[0] = 0x00;              // address MSB
+    data[1] = 0x08;              // address
     data[2] = 0x28 + toneCount;  // address
-    data[3] = address & 127;  // address LSB
-    data[4] = value;                 // data
+    data[3] = address & 127;     // address LSB
+    data[4] = value;             // data
+
     uint32_t checksum = 0;
+
     for (size_t i = 0; i < 5; i++) {
         checksum += data[i];
         if (checksum >= 128) {
@@ -1117,10 +1119,13 @@ void EditToneTab::sendSysexPatchToneChange1Byte(uint8_t address, uint8_t value)
     buf[2] = 0x10; // unit number
     buf[3] = 0x46;
     buf[4] = 0x12; // command
+
     checksum = 128 - checksum;
+
     for (size_t i = 0; i < 5; i++) {
         buf[i + 5] = data[i];
     }
+
     buf[10] = checksum;
     buf[11] = 0xf7;
 
@@ -1138,7 +1143,9 @@ void EditToneTab::sendSysexPatchToneChange2Byte(uint8_t address, uint8_t value)
     data[3] = address & 127;        // address LSB
     data[4] = (value & 0xf0) >> 4;  // data
     data[5] = value & 0x0f;         // data
+
     uint32_t checksum = 0;
+
     for (size_t i = 0; i < 6; i++) {
         checksum += data[i];
         if (checksum >= 128) {
@@ -1152,10 +1159,13 @@ void EditToneTab::sendSysexPatchToneChange2Byte(uint8_t address, uint8_t value)
     buf[2] = 0x10; // unit number
     buf[3] = 0x46;
     buf[4] = 0x12; // command
+
     checksum = 128 - checksum;
+
     for (size_t i = 0; i < 6; i++) {
         buf[i + 5] = data[i];
     }
+
     buf[11] = checksum;
     buf[12] = 0xf7;
 

--- a/Source/ui/widgets/Button.h
+++ b/Source/ui/widgets/Button.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+class Button final : public juce::ToggleButton
+{
+public:
+    Button(uint32_t _id, const juce::String &_name) : juce::ToggleButton(_name), id(_id) {};
+
+    uint32_t getID() { return id; }
+
+private:
+    uint32_t id;
+};

--- a/Source/ui/widgets/Menu.h
+++ b/Source/ui/widgets/Menu.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+class Menu final : public juce::ComboBox
+{
+public:
+    Menu(uint32_t _id) : juce::ComboBox("Menu"), id(_id)
+    {
+        setScrollWheelEnabled(true);
+    };
+
+    uint32_t getID() { return id; }
+
+private:
+    uint32_t id;
+};

--- a/Source/ui/widgets/Slider.h
+++ b/Source/ui/widgets/Slider.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+class Slider : public juce::Slider
+{
+public:
+    Slider(uint32_t _id, double _min, double _max, double _interval)
+        : juce::Slider("Slider"), id(_id), min(_min), max(_max), interval(_interval)
+    {
+        setSliderStyle(juce::Slider::SliderStyle::LinearBar);
+        setRange(min, max, interval);
+    };
+
+    uint32_t getID() { return id; }
+
+private:
+    uint32_t id;
+    double min, max, interval;
+};

--- a/Source/ui/widgets/TextEdit.h
+++ b/Source/ui/widgets/TextEdit.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+class TextEdit final : public juce::TextEditor
+{
+public:
+    TextEdit(uint32_t _id) : juce::TextEditor(), id(_id) {};
+
+    uint32_t getID() { return id; }
+
+private:
+    uint32_t id;
+};

--- a/jv880.jucer
+++ b/jv880.jucer
@@ -14,6 +14,12 @@
       <FILE id="gPg4hs" name="dataStructures.h" compile="0" resource="0"
             file="Source/dataStructures.h"/>
       <GROUP id="{C418E418-6F93-9901-9FC9-85CA2D362048}" name="ui">
+        <GROUP id="{92591F5A-818C-4026-55C3-A90AD50D111D}" name="widgets">
+          <FILE id="ucEKxl" name="Button.h" compile="0" resource="0" file="Source/ui/widgets/Button.h"/>
+          <FILE id="zXQ57H" name="Menu.h" compile="0" resource="0" file="Source/ui/widgets/Menu.h"/>
+          <FILE id="LoE4qt" name="Slider.h" compile="0" resource="0" file="Source/ui/widgets/Slider.h"/>
+          <FILE id="Ie0u9n" name="TextEdit.h" compile="0" resource="0" file="Source/ui/widgets/TextEdit.h"/>
+        </GROUP>
         <FILE id="CEIonD" name="EditCommonTab.cpp" compile="1" resource="0"
               file="Source/ui/EditCommonTab.cpp"/>
         <FILE id="nokpbG" name="EditCommonTab.h" compile="0" resource="0" file="Source/ui/EditCommonTab.h"/>
@@ -147,8 +153,8 @@
     </LINUX_MAKE>
     <VS2022 targetFolder="Builds/VisualStudio2022">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" targetName="jv880"/>
-        <CONFIGURATION isDebug="0" name="Release" targetName="jv880"/>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="jv880" headerPath="C:\Program Files (x86)\Steinberg\ASIOSDK\common\"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="jv880" headerPath="C:\Program Files (x86)\Steinberg\ASIOSDK\common\"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_plugin_client" path="./JUCE/modules"/>


### PR DESCRIPTION
This required subclassing JUCE widgets we're using, in order to attach an integer ID, so that we can efficiently switch-case in the various widget listener callbacks, and send 12 byte sysex instead of 45 byte sysex on every parameter value change.

Other sections will be coming up as time allows.