### PR TITLE
Tweak the layout of Rhythm Set edit tab

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -24,17 +24,6 @@ VirtualJVEditor::VirtualJVEditor(
 
   setSize(820, 900);
 
-  const auto bgColor = getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId);
-
-  tabs.addTab("Browse", bgColor, &patchBrowser, false);
-  tabs.addTab("Common", bgColor, &editCommonTab, false);
-  tabs.addTab("Tone 1", bgColor, &editTone1Tab, false);
-  tabs.addTab("Tone 2", bgColor, &editTone2Tab, false);
-  tabs.addTab("Tone 3", bgColor, &editTone3Tab, false);
-  tabs.addTab("Tone 4", bgColor, &editTone4Tab, false);
-  tabs.addTab("Rhythm", bgColor, &editRhythmTab, false);
-  tabs.addTab("Settings", bgColor, &settingsTab, false);
-
   if (!processor.loaded) {
     juce::AlertWindow::showAsync(
         juce::MessageBoxOptions()
@@ -57,6 +46,7 @@ VirtualJVEditor::VirtualJVEditor(
   else
   {
       updateEditTabs();
+      showToneOrRhythmEditTabs(processor.status.isDrums);
   }
 }
 
@@ -71,6 +61,41 @@ void VirtualJVEditor::updateEditTabs()
     editTone4Tab.updateValues();
     editRhythmTab.updateValues();
     settingsTab.updateValues();
+}
+
+void VirtualJVEditor::showToneOrRhythmEditTabs(const bool isRhythm)
+{
+    const auto bgColor = getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId);
+    const auto selTab = tabs.getCurrentTabIndex();
+
+    tabs.clearTabs();
+
+    if (isRhythm)
+    {
+        tabs.addTab("Browse", bgColor, &patchBrowser, false);
+        tabs.addTab("Settings", bgColor, &settingsTab, false);
+        tabs.addTab("Common", bgColor, &editCommonTab, false);
+        tabs.addTab("Rhythm Set", bgColor, &editRhythmTab, false);
+    }
+    else
+    {
+        tabs.addTab("Browse", bgColor, &patchBrowser, false);
+        tabs.addTab("Settings", bgColor, &settingsTab, false);
+        tabs.addTab("Common", bgColor, &editCommonTab, false);
+        tabs.addTab("Tone 1", bgColor, &editTone1Tab, false);
+        tabs.addTab("Tone 2", bgColor, &editTone2Tab, false);
+        tabs.addTab("Tone 3", bgColor, &editTone3Tab, false);
+        tabs.addTab("Tone 4", bgColor, &editTone4Tab, false);
+    }
+
+    // I don't know if the selected tab index resets after calling clearTabs(),
+    // so just making sure that we stay where we were before the tab clearout
+    if (selTab >= 3 && selTab <= 6)
+    {
+        tabs.setCurrentTabIndex(3);
+    }
+
+    editCommonTab.rhythmSetMode(isRhythm);
 }
 
 uint8_t VirtualJVEditor::getSelectedRomIdx()

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #include <JuceHeader.h>
+
 #include "PluginProcessor.h"
+
 #include "ui/widgets/LCDisplay.h"
 #include "ui/PatchBrowser.h"
 #include "ui/EditCommonTab.h"
@@ -31,6 +33,7 @@ public:
 
     uint8_t getSelectedRomIdx();
     void updateEditTabs();
+    void showToneOrRhythmEditTabs(const bool isRhythm);
 
 private:
     VirtualJVProcessor& processor;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -31,6 +31,36 @@ VirtualJVProcessor::VirtualJVProcessor()
 
   patchInfoPerGroup.push_back(std::vector<PatchInfo *>());
 
+  // Internal A
+  for (int j = 0; j < 64; j++) {
+      patchInfos[currentPatchI].name =
+          (const char*)&loadedRoms[getRomIndex("jv880_rom2.bin")]
+          [0x010ce0 + j * 0x16a];
+      patchInfos[currentPatchI].nameLength = 0xc;
+      patchInfos[currentPatchI].expansionI = 0xff;
+      patchInfos[currentPatchI].patchI = j;
+      patchInfos[currentPatchI].present = true;
+      patchInfos[currentPatchI].drums = false;
+      patchInfos[currentPatchI].iInList = currentPatchI;
+      patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
+      currentPatchI++;
+  }
+
+  // Internal B
+  for (int j = 0; j < 64; j++) {
+      patchInfos[currentPatchI].name =
+          (const char*)&loadedRoms[getRomIndex("jv880_rom2.bin")]
+          [0x018ce0 + j * 0x16a];
+      patchInfos[currentPatchI].nameLength = 0xc;
+      patchInfos[currentPatchI].expansionI = 0xff;
+      patchInfos[currentPatchI].patchI = j;
+      patchInfos[currentPatchI].present = true;
+      patchInfos[currentPatchI].drums = false;
+      patchInfos[currentPatchI].iInList = currentPatchI;
+      patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
+      currentPatchI++;
+  }
+
   // Internal User
   for (int j = 0; j < 64; j++) {
     patchInfos[currentPatchI].name =
@@ -45,33 +75,8 @@ VirtualJVProcessor::VirtualJVProcessor()
     patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
     currentPatchI++;
   }
-  patchInfos[currentPatchI].name = "Drums Internal User";
-  patchInfos[currentPatchI].ptr =
-      (char *)&loadedRoms[getRomIndex("jv880_rom2.bin")][0x00e760];
-  patchInfos[currentPatchI].nameLength = 21;
-  patchInfos[currentPatchI].expansionI = 0xff;
-  patchInfos[currentPatchI].patchI = 0;
-  patchInfos[currentPatchI].present = true;
-  patchInfos[currentPatchI].drums = true;
-  patchInfos[currentPatchI].iInList = currentPatchI;
-  patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
-  currentPatchI++;
 
-  // Internal A
-  for (int j = 0; j < 64; j++) {
-    patchInfos[currentPatchI].name =
-        (const char *)&loadedRoms[getRomIndex("jv880_rom2.bin")]
-                                 [0x010ce0 + j * 0x16a];
-    patchInfos[currentPatchI].nameLength = 0xc;
-    patchInfos[currentPatchI].expansionI = 0xff;
-    patchInfos[currentPatchI].patchI = j;
-    patchInfos[currentPatchI].present = true;
-    patchInfos[currentPatchI].drums = false;
-    patchInfos[currentPatchI].iInList = currentPatchI;
-    patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
-    currentPatchI++;
-  }
-  patchInfos[currentPatchI].name = "Drums Internal A";
+  patchInfos[currentPatchI].name = "Rhythm Set Int A";
   patchInfos[currentPatchI].ptr =
       (char *)&loadedRoms[getRomIndex("jv880_rom2.bin")][0x016760];
   patchInfos[currentPatchI].nameLength = 21;
@@ -83,23 +88,21 @@ VirtualJVProcessor::VirtualJVProcessor()
   patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
   currentPatchI++;
 
-  // Internal B
-  for (int j = 0; j < 64; j++) {
-    patchInfos[currentPatchI].name =
-        (const char *)&loadedRoms[getRomIndex("jv880_rom2.bin")]
-                                 [0x018ce0 + j * 0x16a];
-    patchInfos[currentPatchI].nameLength = 0xc;
-    patchInfos[currentPatchI].expansionI = 0xff;
-    patchInfos[currentPatchI].patchI = j;
-    patchInfos[currentPatchI].present = true;
-    patchInfos[currentPatchI].drums = false;
-    patchInfos[currentPatchI].iInList = currentPatchI;
-    patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
-    currentPatchI++;
-  }
-  patchInfos[currentPatchI].name = "Drums Internal B";
+  patchInfos[currentPatchI].name = "Rhythm Set Int B";
   patchInfos[currentPatchI].ptr =
       (char *)&loadedRoms[getRomIndex("jv880_rom2.bin")][0x01e760];
+  patchInfos[currentPatchI].nameLength = 21;
+  patchInfos[currentPatchI].expansionI = 0xff;
+  patchInfos[currentPatchI].patchI = 0;
+  patchInfos[currentPatchI].present = true;
+  patchInfos[currentPatchI].drums = true;
+  patchInfos[currentPatchI].iInList = currentPatchI;
+  patchInfoPerGroup[0].push_back(&patchInfos[currentPatchI]);
+  currentPatchI++;
+
+  patchInfos[currentPatchI].name = "Rhythm Set User";
+  patchInfos[currentPatchI].ptr =
+      (char*)&loadedRoms[getRomIndex("jv880_rom2.bin")][0x00e760];
   patchInfos[currentPatchI].nameLength = 21;
   patchInfos[currentPatchI].expansionI = 0xff;
   patchInfos[currentPatchI].patchI = 0;
@@ -175,7 +178,7 @@ VirtualJVProcessor::VirtualJVProcessor()
 
       char *namePtr = (char *)calloc(32, 1);
       patchInfos[currentPatchI].name = namePtr;
-      sprintf(namePtr, "Exp %d Drums %d", i, j);
+      sprintf(namePtr, "Rhythm Set %d", j + 1);
 
       patchInfos[currentPatchI].ptr =
           (const char *)&expansionsDescr[i][patchesOffset + j * 0xa7c];
@@ -277,7 +280,10 @@ void VirtualJVProcessor::setCurrentProgram(int index) {
 
   if (auto editor = getActiveEditor())
   {
-      dynamic_cast<VirtualJVEditor*>(editor)->updateEditTabs();
+      auto e = dynamic_cast<VirtualJVEditor*>(editor);
+
+      e->showToneOrRhythmEditTabs(status.isDrums);
+      e->updateEditTabs();
   }
 }
 
@@ -390,7 +396,10 @@ void VirtualJVProcessor::setStateInformation(const void *data,
 
   if (auto editor = getActiveEditor())
   {
-      dynamic_cast<VirtualJVEditor*>(editor)->updateEditTabs();
+      auto e = dynamic_cast<VirtualJVEditor*>(editor);
+
+      e->showToneOrRhythmEditTabs(status.isDrums);
+      e->updateEditTabs();
   }
 }
 

--- a/Source/ui/EditCommonTab.cpp
+++ b/Source/ui/EditCommonTab.cpp
@@ -194,6 +194,22 @@ void EditCommonTab::updateValues()
     portamentoTimeSlider    .setValue(patch->portamentoTime & 0x7f, juce::dontSendNotification);
 }
 
+void EditCommonTab::rhythmSetMode(const bool isRhythm)
+{
+    velocitySwitchToggle  .setVisible(!isRhythm);
+    levelSlider           .setVisible(!isRhythm);
+    panSlider             .setVisible(!isRhythm);
+    analogFeelSlider      .setVisible(!isRhythm);
+    bendRangeDownSlider   .setVisible(!isRhythm);
+    bendRangeUpSlider     .setVisible(!isRhythm);
+    keyAssignComboBox     .setVisible(!isRhythm);
+    soloLegatoToggle      .setVisible(!isRhythm);
+    portamentoToggle      .setVisible(!isRhythm);
+    portamentoModeComboBox.setVisible(!isRhythm);
+    portamentoTypeComboBox.setVisible(!isRhythm);
+    portamentoTimeSlider  .setVisible(!isRhythm);
+}
+
 void EditCommonTab::resized()
 {
     const auto top = 30;

--- a/Source/ui/EditCommonTab.h
+++ b/Source/ui/EditCommonTab.h
@@ -41,6 +41,7 @@ public:
   void textEditorTextChanged(juce::TextEditor &) override;
 
   void updateValues();
+  void rhythmSetMode(const bool isRhythm);
 
   void sendSysexPatchNameChange();
   void sendSysexPatchCommonParamChange(const uint8_t address, const uint8_t value);

--- a/Source/ui/EditRhythmTab.cpp
+++ b/Source/ui/EditRhythmTab.cpp
@@ -8,25 +8,42 @@
   ==============================================================================
 */
 
-#include <JuceHeader.h>
 #include <algorithm>
+#include <JuceHeader.h>
+
 #include "EditRhythmTab.h"
+
+#include "../dataStructures.h"
+#include "../PluginEditor.h"
 
 //==============================================================================
 EditRhythmTab::EditRhythmTab
-    ( VirtualJVProcessor &p, VirtualJVEditor *e)
+(VirtualJVProcessor& p, VirtualJVEditor* e)
     : processor(p), editor(e)
 {
     toneCount = 0;
-    
-    addAndMakeVisible(toneSlider);
-    toneSlider.setValue(36);
-    toneSlider.addListener(this);
+
+    const std::array<std::string, 12> noteNames{ "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "Bb", "B" };
+
+    addAndMakeVisible(selectKeyComboBox);
+    selectKeyComboBox.addListener(this);
+
+    for (uint8_t i = 36; i <= 96; i++)
+    {
+        if (i % 12 == 0 and i > 36)
+        {
+            selectKeyComboBox.getRootMenu()->addColumnBreak();
+        }
+
+        selectKeyComboBox.addItem(noteNames[i % 12] + std::to_string((i / 12) - 1) + " (" + std::to_string(i) + ")", i);
+    }
+
+    selectKeyComboBox.setSelectedItemIndex(0);
+
     addAndMakeVisible(toneLabel);
-    toneLabel.setText("Tone Key", juce::dontSendNotification);
-    toneLabel.attachToComponent(&toneSlider, true);
-    
-    
+    toneLabel.setText("Key", juce::dontSendNotification);
+    toneLabel.attachToComponent(&selectKeyComboBox, true);
+
     addAndMakeVisible(waveGroupLabel);
     waveGroupLabel.setText("Wave Group", juce::dontSendNotification);
     waveGroupLabel.attachToComponent(&waveGroupComboBox, true);
@@ -47,18 +64,21 @@ EditRhythmTab::EditRhythmTab
 
     addAndMakeVisible(toneSwitchToggle);
     toneSwitchToggle.addListener(this);
-    
-    addAndMakeVisible(envModeComboBox);
-    envModeComboBox.addListener(this);
-    envModeComboBox.addItem("No Sus", 1);
-    envModeComboBox.addItem("Sustain", 2);
-    
+
     addAndMakeVisible(muteSlider);
     muteSlider.addListener(this);
     addAndMakeVisible(muteLabel);
-    muteLabel.setText("Mute/Env", juce::dontSendNotification);
+    muteLabel.setText("Mute Group", juce::dontSendNotification);
     muteLabel.attachToComponent(&muteSlider, true);
-    
+
+    addAndMakeVisible(envModeComboBox);
+    envModeComboBox.addListener(this);
+    envModeComboBox.addItem("Oneshot", 1);
+    envModeComboBox.addItem("Sustain", 2);
+    addAndMakeVisible(envModeLabel);
+    envModeLabel.setText("Env Mode", juce::dontSendNotification);
+    envModeLabel.attachToComponent(&envModeComboBox, true);
+
     addAndMakeVisible(pitchCoarseSlider);
     pitchCoarseSlider.addListener(this);
     addAndMakeVisible(pitchCoarseLabel);
@@ -91,9 +111,9 @@ EditRhythmTab::EditRhythmTab
     pitchRandomComboBox.addListener(this);
     addMenuEntriesFromArray(pitchRandomComboBox, pitchRandoms);
     addAndMakeVisible(pitchRandomLabel);
-    pitchRandomLabel.setText("Random | KF", juce::dontSendNotification);
+    pitchRandomLabel.setText("Random", juce::dontSendNotification);
     pitchRandomLabel.attachToComponent(&pitchRandomComboBox, true);
-    
+
     addAndMakeVisible(bendRangeSlider);
     bendRangeSlider.addListener(this);
     addAndMakeVisible(bendRangeLabel);
@@ -308,14 +328,13 @@ EditRhythmTab::EditRhythmTab
     addAndMakeVisible(outputLabel);
     outputLabel.setText("Output", juce::dontSendNotification);
     outputLabel.attachToComponent(&outputComboBox, true);
-
 }
 
 EditRhythmTab::~EditRhythmTab()
 {
 }
 
-void EditRhythmTab::addMenuEntriesFromArray(Menu &m, const std::vector<std::string> &array)
+void EditRhythmTab::addMenuEntriesFromArray(Menu& m, const std::vector<std::string>& array)
 {
     uint32_t idx = 1;
 
@@ -326,7 +345,7 @@ void EditRhythmTab::addMenuEntriesFromArray(Menu &m, const std::vector<std::stri
     }
 }
 
-void EditRhythmTab::updateWaveformComboBox(Menu &wfMenu)
+void EditRhythmTab::updateWaveformComboBox(Menu& wfMenu)
 {
     const int priorSelection = wfMenu.getSelectedItemIndex();
 
@@ -345,7 +364,7 @@ void EditRhythmTab::updateWaveformComboBox(Menu &wfMenu)
             wfMenu.getRootMenu()->addColumnBreak();
         }
 
-        wfMenu.addItem(std::string{std::to_string(i + 1) + ": " + names[i]}, i + 1);
+        wfMenu.addItem(std::string{ std::to_string(i + 1) + ": " + names[i] }, i + 1);
     }
 
     if (priorSelection > -1)
@@ -360,15 +379,17 @@ void EditRhythmTab::updateValues()
 {
     Rhythm* rhythm = (Rhythm*)processor.status.drums;
     RhythmTone tone = rhythm->tones[toneCount];
-    waveGroupComboBox.setSelectedItemIndex((tone.flags & 0x3), juce::dontSendNotification);
-    waveformComboBox.setSelectedItemIndex((tone.waveNumber & 0xff), juce::dontSendNotification);
+
     toneSwitchToggle.setToggleState(((tone.flags >> 7) & 0x01) ? 1 : 0, juce::dontSendNotification);
 
+    waveGroupComboBox.setSelectedItemIndex((tone.flags & 0x3), juce::dontSendNotification);
+    waveformComboBox.setSelectedItemIndex((tone.waveNumber & 0xff), juce::dontSendNotification);
+
     updateWaveformComboBox(waveformComboBox);
-    
+
     muteSlider.setValue(int8_t((tone.muteGroup) & 0x1f), juce::dontSendNotification);
     envModeComboBox.setSelectedItemIndex((((tone.muteGroup) >> 5) & 0x01), juce::dontSendNotification);
-    
+
     pitchCoarseSlider.setValue(int8_t((tone.pitchCoarse) - 64), juce::dontSendNotification);
     pitchFineSlider.setValue(int8_t((tone.pitchFine)), juce::dontSendNotification);
     pitchRandomComboBox.setSelectedItemIndex((tone.pitchRandom), juce::dontSendNotification);
@@ -403,7 +424,7 @@ void EditRhythmTab::updateValues()
 
     levelSlider.setValue(int8_t((tone.tvaLevel)), juce::dontSendNotification);
     panSlider.setValue(int8_t(tone.tvaPan - 64), juce::dontSendNotification);
-    
+
     aenvLevSensSlider.setValue(int8_t((tone.tvaVelocity)), juce::dontSendNotification);
     aenvTimeSensComboBox.setSelectedItemIndex((tone.tvaTimeVelocity & 0x0f), juce::dontSendNotification);
     aenv1TimeSlider.setValue(int8_t((tone.tvaEnvTime1 & 0x7f)), juce::dontSendNotification);
@@ -426,70 +447,69 @@ void EditRhythmTab::resized()
     const auto sliderLeft1 = 100;
     const auto width = getWidth() / 3 - sliderLeft1 - 10;
     const auto halfWidth = width / 2;
+    const auto thirdWidth = width / 3;
     const auto sliderLeft2 = sliderLeft1 + getWidth() / 3 + 10;
     const auto sliderLeft3 = sliderLeft2 + getWidth() / 3 - 10;
     const auto height = 24;
     const auto vMargin = 24;
 
-    toneSwitchToggle      .setBounds(sliderLeft1 - 90, top + height * 0 + vMargin * 0, width, height);
+    toneSwitchToggle.setBounds(sliderLeft1 - 90, top + height * 0 + vMargin * 0, width, height);
+    selectKeyComboBox.setBounds(sliderLeft1 + thirdWidth, top + height * 0 + vMargin * 0, thirdWidth * 2, height);
 
-    waveGroupComboBox     .setBounds(sliderLeft1, top + height * 1 + vMargin * 1, width, height);
-    waveformComboBox      .setBounds(sliderLeft1, top + height * 2 + vMargin * 1, width, height);
+    waveGroupComboBox.setBounds(sliderLeft1, top + height * 1 + vMargin * 1, width, height);
+    waveformComboBox.setBounds(sliderLeft1, top + height * 2 + vMargin * 1, width, height);
 
-    muteSlider     .setBounds(sliderLeft1, top + height * 3 + vMargin * 2, halfWidth, height);
-    envModeComboBox    .setBounds(sliderLeft1 + halfWidth, top + height * 3 + vMargin * 2, halfWidth, height);
-    bendRangeSlider    .setBounds(sliderLeft1, top + height * 4 + vMargin * 2, width, height);
-    
-    
-    toneSlider    .setBounds(sliderLeft1, top + height * 21 + vMargin * 6, width, height);
+    bendRangeSlider.setBounds(sliderLeft2, top + height * 0 + vMargin * 0, width, height);
+    pitchCoarseSlider.setBounds(sliderLeft2, top + height * 1 + vMargin * 0, width, height);
+    pitchFineSlider.setBounds(sliderLeft2, top + height * 2 + vMargin * 0, width, height);
+    pitchRandomComboBox.setBounds(sliderLeft2, top + height * 3 + vMargin * 0, width, height);
+    penvLevSensSlider.setBounds(sliderLeft2, top + height * 4 + vMargin * 0, width, height);
+    penvTimeSensComboBox.setBounds(sliderLeft2, top + height * 5 + vMargin * 0, width, height);
 
-    pitchCoarseSlider     .setBounds(sliderLeft2, top + height * 1 + vMargin * 0, width, height);
-    pitchFineSlider       .setBounds(sliderLeft2, top + height * 2 + vMargin * 0, width, height);
-    pitchRandomComboBox   .setBounds(sliderLeft2, top + height * 3 + vMargin * 0, halfWidth, height);
-    penvLevSensSlider     .setBounds(sliderLeft2, top + height * 4 + vMargin * 0, width, height);
-    penvTimeSensComboBox .setBounds(sliderLeft2, top + height * 5 + vMargin * 0, halfWidth, height);
-    penvDepthSlider       .setBounds(sliderLeft2, top + height * 7 + vMargin * 0, width, height);
-    penv1TimeSlider       .setBounds(sliderLeft2, top + height * 8 + vMargin * 0, halfWidth, height);
-    penv1LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 8 + vMargin * 0, halfWidth, height);
-    penv2TimeSlider       .setBounds(sliderLeft2, top + height * 9 + vMargin * 0, halfWidth, height);
-    penv2LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 9 + vMargin * 0, halfWidth, height);
-    penv3TimeSlider       .setBounds(sliderLeft2, top + height * 10 + vMargin * 0, halfWidth, height);
-    penv3LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 10 + vMargin * 0, halfWidth, height);
-    penv4TimeSlider       .setBounds(sliderLeft2, top + height * 11 + vMargin * 0, halfWidth, height);
-    penv4LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 11 + vMargin * 0, halfWidth, height);
+    penvDepthSlider.setBounds(sliderLeft2, top + height * 6 + vMargin * 0, width, height);
+    penv1TimeSlider.setBounds(sliderLeft2, top + height * 7 + vMargin * 0, halfWidth, height);
+    penv1LevelSlider.setBounds(sliderLeft2 + halfWidth, top + height * 7 + vMargin * 0, halfWidth, height);
+    penv2TimeSlider.setBounds(sliderLeft2, top + height * 8 + vMargin * 0, halfWidth, height);
+    penv2LevelSlider.setBounds(sliderLeft2 + halfWidth, top + height * 8 + vMargin * 0, halfWidth, height);
+    penv3TimeSlider.setBounds(sliderLeft2, top + height * 9 + vMargin * 0, halfWidth, height);
+    penv3LevelSlider.setBounds(sliderLeft2 + halfWidth, top + height * 9 + vMargin * 0, halfWidth, height);
+    penv4TimeSlider.setBounds(sliderLeft2, top + height * 10 + vMargin * 0, halfWidth, height);
+    penv4LevelSlider.setBounds(sliderLeft2 + halfWidth, top + height * 10 + vMargin * 0, halfWidth, height);
 
-    levelSlider           .setBounds(sliderLeft2, top + height * 12 + vMargin * 1, width, height);
-    panSlider             .setBounds(sliderLeft2, top + height * 13 + vMargin * 1, width, height);
-    aenvLevSensSlider     .setBounds(sliderLeft2, top + height * 18 + vMargin * 1, width, height);
-    aenvTimeSensComboBox  .setBounds(sliderLeft2, top + height * 19 + vMargin * 1, halfWidth, height);
-    aenv1TimeSlider       .setBounds(sliderLeft2, top + height * 21 + vMargin * 1, halfWidth, height);
-    aenv1LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 21 + vMargin * 1, halfWidth, height);
-    aenv2TimeSlider       .setBounds(sliderLeft2, top + height * 22 + vMargin * 1, halfWidth, height);
-    aenv2LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 22 + vMargin * 1, halfWidth, height);
-    aenv3TimeSlider       .setBounds(sliderLeft2, top + height * 23 + vMargin * 1, halfWidth, height);
-    aenv3LevelSlider      .setBounds(sliderLeft2 + halfWidth, top + height * 23 + vMargin * 1, halfWidth, height);
-    aenv4TimeSlider       .setBounds(sliderLeft2, top + height * 24 + vMargin * 1, halfWidth, height);
+    muteSlider.setBounds(sliderLeft1, top + height * 3 + vMargin * 2, width, height);
+    envModeComboBox.setBounds(sliderLeft1, top + height * 4 + vMargin * 2, width, height);
+    levelSlider.setBounds(sliderLeft1, top + height * 5 + vMargin * 2, width, height);
+    panSlider.setBounds(sliderLeft1, top + height * 6 + vMargin * 2, width, height);
+    aenvLevSensSlider.setBounds(sliderLeft1, top + height * 7 + vMargin * 2, width, height);
+    aenvTimeSensComboBox.setBounds(sliderLeft1, top + height * 8 + vMargin * 2, width, height);
+    aenv1TimeSlider.setBounds(sliderLeft1, top + height * 9 + vMargin * 2, halfWidth, height);
+    aenv1LevelSlider.setBounds(sliderLeft1 + halfWidth, top + height * 9 + vMargin * 2, halfWidth, height);
+    aenv2TimeSlider.setBounds(sliderLeft1, top + height * 10 + vMargin * 2, halfWidth, height);
+    aenv2LevelSlider.setBounds(sliderLeft1 + halfWidth, top + height * 10 + vMargin * 2, halfWidth, height);
+    aenv3TimeSlider.setBounds(sliderLeft1, top + height * 11 + vMargin * 2, halfWidth, height);
+    aenv3LevelSlider.setBounds(sliderLeft1 + halfWidth, top + height * 11 + vMargin * 2, halfWidth, height);
+    aenv4TimeSlider.setBounds(sliderLeft1, top + height * 12 + vMargin * 2, halfWidth, height);
 
-    filterModeComboBox    .setBounds(sliderLeft3, top + height * 0 + vMargin * 0, width, height);
-    filterCutoffSlider    .setBounds(sliderLeft3, top + height * 1 + vMargin * 0, width, height);
-    filterResoSlider      .setBounds(sliderLeft3, top + height * 2 + vMargin * 0, halfWidth, height);
+    filterModeComboBox.setBounds(sliderLeft3, top + height * 0 + vMargin * 0, width, height);
+    filterCutoffSlider.setBounds(sliderLeft3, top + height * 1 + vMargin * 0, width, height);
+    filterResoSlider.setBounds(sliderLeft3, top + height * 2 + vMargin * 0, halfWidth, height);
     filterResoModeComboBox.setBounds(sliderLeft3 + halfWidth, top + height * 2 + vMargin * 0, halfWidth, height);
-    fenvLevSensSlider     .setBounds(sliderLeft3, top + height * 4 + vMargin * 0, width, height);
-    fenvTimeSensComboBox .setBounds(sliderLeft3, top + height * 5 + vMargin * 0, halfWidth, height);
-    fenvDepthSlider       .setBounds(sliderLeft3, top + height * 7 + vMargin * 0, width, height);
-    fenv1TimeSlider       .setBounds(sliderLeft3, top + height * 8 + vMargin * 0, halfWidth, height);
-    fenv1LevelSlider      .setBounds(sliderLeft3 + halfWidth, top + height * 8 + vMargin * 0, halfWidth, height);
-    fenv2TimeSlider       .setBounds(sliderLeft3, top + height * 9 + vMargin * 0, halfWidth, height);
-    fenv2LevelSlider      .setBounds(sliderLeft3 + halfWidth, top + height * 9 + vMargin * 0, halfWidth, height);
-    fenv3TimeSlider       .setBounds(sliderLeft3, top + height * 10 + vMargin * 0, halfWidth, height);
-    fenv3LevelSlider      .setBounds(sliderLeft3 + halfWidth, top + height * 10 + vMargin * 0, halfWidth, height);
-    fenv4TimeSlider       .setBounds(sliderLeft3, top + height * 11 + vMargin * 0, halfWidth, height);
-    fenv4LevelSlider      .setBounds(sliderLeft3 + halfWidth, top + height * 11 + vMargin * 0, halfWidth, height);
+    fenvLevSensSlider.setBounds(sliderLeft3, top + height * 3 + vMargin * 0, width, height);
+    fenvTimeSensComboBox.setBounds(sliderLeft3, top + height * 4 + vMargin * 0, width, height);
+    fenvDepthSlider.setBounds(sliderLeft3, top + height * 5 + vMargin * 0, width, height);
+    fenv1TimeSlider.setBounds(sliderLeft3, top + height * 6 + vMargin * 0, halfWidth, height);
+    fenv1LevelSlider.setBounds(sliderLeft3 + halfWidth, top + height * 6 + vMargin * 0, halfWidth, height);
+    fenv2TimeSlider.setBounds(sliderLeft3, top + height * 7 + vMargin * 0, halfWidth, height);
+    fenv2LevelSlider.setBounds(sliderLeft3 + halfWidth, top + height * 7 + vMargin * 0, halfWidth, height);
+    fenv3TimeSlider.setBounds(sliderLeft3, top + height * 8 + vMargin * 0, halfWidth, height);
+    fenv3LevelSlider.setBounds(sliderLeft3 + halfWidth, top + height * 8 + vMargin * 0, halfWidth, height);
+    fenv4TimeSlider.setBounds(sliderLeft3, top + height * 9 + vMargin * 0, halfWidth, height);
+    fenv4LevelSlider.setBounds(sliderLeft3 + halfWidth, top + height * 9 + vMargin * 0, halfWidth, height);
 
-    drySlider             .setBounds(sliderLeft3, top + height * 12 + vMargin * 1, width, height);
-    reverbSlider          .setBounds(sliderLeft3, top + height * 13 + vMargin * 1, width, height);
-    chorusSlider          .setBounds(sliderLeft3, top + height * 14 + vMargin * 1, width, height);
-    outputComboBox        .setBounds(sliderLeft3, top + height * 15 + vMargin * 1, width, height);
+    drySlider.setBounds(sliderLeft3, top + height * 10 + vMargin * 1, width, height);
+    reverbSlider.setBounds(sliderLeft3, top + height * 11 + vMargin * 1, width, height);
+    chorusSlider.setBounds(sliderLeft3, top + height * 12 + vMargin * 1, width, height);
+    outputComboBox.setBounds(sliderLeft3, top + height * 13 + vMargin * 1, width, height);
 }
 
 void EditRhythmTab::sliderValueChanged(juce::Slider* slider)
@@ -500,178 +520,174 @@ void EditRhythmTab::sliderValueChanged(juce::Slider* slider)
     {
         id = i->getID();
     }
-    
+
     Rhythm* rhythm = (Rhythm*)processor.status.drums;
     RhythmTone* tone = &rhythm->tones[toneCount];
-    
-    switch(id)
+
+    switch (id)
     {
-        case toneSelect:
-            toneCount = uint8_t(slider->getValue()) - 36;
-            updateValues();
-            break;
-        case waveform:
-            sendSysexPatchRhythmChange2Byte(0x01, uint8_t(waveformComboBox.getSelectedItemIndex()));
-            tone->waveNumber = uint8_t(waveformComboBox.getSelectedItemIndex());
-            break;
-        case pitchCoarse:
-            sendSysexPatchRhythmChange1Byte(0x04, uint8_t(pitchCoarseSlider.getValue() + 64));
-            tone->pitchCoarse = uint8_t(pitchCoarseSlider.getValue() + 64);
-            break;
-        case mute:
-            sendSysexPatchRhythmChange1Byte(0x05, uint8_t(muteSlider.getValue()));
-            tone->muteGroup = uint8_t((uint8_t(muteSlider.getValue()) << 0) + (envModeComboBox.getSelectedItemIndex() << 5));
-            break;
-        case pitchFine:
-            sendSysexPatchRhythmChange1Byte(0x07, uint8_t(pitchFineSlider.getValue() + 64));
-            tone->pitchFine = uint8_t(pitchFineSlider.getValue());
-            break;
-        case bendRange:
-            sendSysexPatchRhythmChange1Byte(0x09, uint8_t(bendRangeSlider.getValue()));
-            tone->bendRange = uint8_t(penvTimeSensComboBox.getSelectedItemIndex() + (uint8_t(bendRangeSlider.getValue()) << 4));
-            break;
-        case penvLevSens:
-            sendSysexPatchRhythmChange1Byte(0x0a, uint8_t(penvLevSensSlider.getValue() + 64));
-            tone->tvpVelocity = uint8_t(penvLevSensSlider.getValue());
-            break;
-        case penvDepth:
-            sendSysexPatchRhythmChange1Byte(0x0c, uint8_t(penvDepthSlider.getValue() + 64));
-            tone->tvpEnvDepth = uint8_t(penvDepthSlider.getValue());
-            break;
-        case penv1Time:
-            sendSysexPatchRhythmChange1Byte(0x0d, uint8_t(penv1TimeSlider.getValue()));
-            tone->tvpEnvTime1 = uint8_t(penv1TimeSlider.getValue());
-            break;
-        case penv1Level:
-            sendSysexPatchRhythmChange1Byte(0x0e, uint8_t(penv1LevelSlider.getValue() + 64));
-            tone->tvpEnvLevel1 = uint8_t(penv1LevelSlider.getValue());
-            break;
-        case penv2Time:
-            sendSysexPatchRhythmChange1Byte(0x0f, uint8_t(penv2TimeSlider.getValue()));
-            tone->tvpEnvTime2 = uint8_t(penv2TimeSlider.getValue());
-            break;
-        case penv2Level:
-            sendSysexPatchRhythmChange1Byte(0x10, uint8_t(penv2LevelSlider.getValue() + 64));
-            tone->tvpEnvLevel2 = uint8_t(penv2LevelSlider.getValue());
-            break;
-        case penv3Time:
-            sendSysexPatchRhythmChange1Byte(0x11, uint8_t(penv3TimeSlider.getValue()));
-            tone->tvpEnvTime3 = uint8_t(penv3TimeSlider.getValue());
-            break;
-        case penv3Level:
-            sendSysexPatchRhythmChange1Byte(0x12, uint8_t(penv3LevelSlider.getValue() + 64));
-            tone->tvpEnvLevel3 = uint8_t(penv3LevelSlider.getValue());
-            break;
-        case penv4Time:
-            sendSysexPatchRhythmChange1Byte(0x13, uint8_t(penv4TimeSlider.getValue()));
-            tone->tvpEnvTime4 = uint8_t(penv4TimeSlider.getValue());
-            break;
-        case penv4Level:
-            sendSysexPatchRhythmChange1Byte(0x14, uint8_t(penv4LevelSlider.getValue() + 64));
-            tone->tvpEnvLevel4 = uint8_t(penv4LevelSlider.getValue());
-            break;
-        case filterCutoff:
-            sendSysexPatchRhythmChange1Byte(0x16, uint8_t(filterCutoffSlider.getValue()));
-            tone->tvfCutoff = uint8_t(filterCutoffSlider.getValue());
-            break;
-        case filterReso:
-            sendSysexPatchRhythmChange1Byte(0x17, uint8_t(filterResoSlider.getValue()));
-            tone->tvfResonance = uint8_t(filterResoSlider.getValue() + (filterResoModeComboBox.getSelectedItemIndex() << 7));
-            break;
-        case fenvLevSens:
-            sendSysexPatchRhythmChange1Byte(0x19, uint8_t(fenvLevSensSlider.getValue() + 64));
-            tone->tvfVelocity = uint8_t(fenvLevSensSlider.getValue());
-            break;
-        case fenvDepth:
-            sendSysexPatchRhythmChange1Byte(0x1b, uint8_t(fenvDepthSlider.getValue() + 64));
-            tone->tvfEnvDepth = uint8_t(fenvDepthSlider.getValue());
-            break;
-        case fenv1Time:
-            sendSysexPatchRhythmChange1Byte(0x1c, uint8_t(fenv1TimeSlider.getValue()));
-            tone->tvfEnvTime1 = uint8_t(fenv1TimeSlider.getValue());
-            break;
-        case fenv1Level:
-            sendSysexPatchRhythmChange1Byte(0x1d, uint8_t(fenv1LevelSlider.getValue()));
-            tone->tvfEnvLevel1 = uint8_t(fenv1LevelSlider.getValue());
-            break;
-        case fenv2Time:
-            sendSysexPatchRhythmChange1Byte(0x1e, uint8_t(fenv2TimeSlider.getValue()));
-            tone->tvfEnvTime2 = uint8_t(fenv2TimeSlider.getValue());
-            break;
-        case fenv2Level:
-            sendSysexPatchRhythmChange1Byte(0x1f, uint8_t(fenv2LevelSlider.getValue()));
-            tone->tvfEnvLevel2 = uint8_t(fenv2LevelSlider.getValue());
-            break;
-        case fenv3Time:
-            sendSysexPatchRhythmChange1Byte(0x20, uint8_t(fenv3TimeSlider.getValue()));
-            tone->tvfEnvTime3 = uint8_t(fenv3TimeSlider.getValue());
-            break;
-        case fenv3Level:
-            sendSysexPatchRhythmChange1Byte(0x21, uint8_t(fenv3LevelSlider.getValue()));
-            tone->tvfEnvLevel3 = uint8_t(fenv3LevelSlider.getValue());
-            break;
-        case fenv4Time:
-            sendSysexPatchRhythmChange1Byte(0x22, uint8_t(fenv4TimeSlider.getValue()));
-            tone->tvfEnvTime4 = uint8_t(fenv4TimeSlider.getValue());
-            break;
-        case fenv4Level:
-            sendSysexPatchRhythmChange1Byte(0x23, uint8_t(fenv4LevelSlider.getValue()));
-            tone->tvfEnvLevel4 = uint8_t(fenv4LevelSlider.getValue());
-            break;
-        case level:
-            sendSysexPatchRhythmChange1Byte(0x24, uint8_t(levelSlider.getValue()));
-            tone->tvaLevel = uint8_t(levelSlider.getValue());
-            break;
-        case pan:
-            sendSysexPatchRhythmChange2Byte(0x25, uint8_t(panSlider.getValue() + 64));
-            tone->tvaPan = uint8_t(panSlider.getValue() + 64);
-            break;
-        case aenvLevSens:
-            sendSysexPatchRhythmChange1Byte(0x27, uint8_t(aenvLevSensSlider.getValue() + 64));
-            tone->tvaVelocity = uint8_t(aenvLevSensSlider.getValue());
-            break;
-        case aenv1Time:
-            sendSysexPatchRhythmChange1Byte(0x29, uint8_t(aenv1TimeSlider.getValue()));
-            tone->tvaEnvTime1 = uint8_t(aenv1TimeSlider.getValue());
-            break;
-        case aenv1Level:
-            sendSysexPatchRhythmChange1Byte(0x2a, uint8_t(aenv1LevelSlider.getValue()));
-            tone->tvaEnvLevel1 = uint8_t(aenv1LevelSlider.getValue());
-            break;
-        case aenv2Time:
-            sendSysexPatchRhythmChange1Byte(0x2b, uint8_t(aenv2TimeSlider.getValue()));
-            tone->tvaEnvTime2 = uint8_t(aenv2TimeSlider.getValue());
-            break;
-        case aenv2Level:
-            sendSysexPatchRhythmChange1Byte(0x2c, uint8_t(aenv2LevelSlider.getValue()));
-            tone->tvaEnvLevel2 = uint8_t(aenv2LevelSlider.getValue());
-            break;
-        case aenv3Time:
-            sendSysexPatchRhythmChange1Byte(0x2d, uint8_t(aenv3TimeSlider.getValue()));
-            tone->tvaEnvTime3 = uint8_t(aenv3TimeSlider.getValue());
-            break;
-        case aenv3Level:
-            sendSysexPatchRhythmChange1Byte(0x2e, uint8_t(aenv3LevelSlider.getValue()));
-            tone->tvaEnvLevel3 = uint8_t(aenv3LevelSlider.getValue());
-            break;
-        case aenv4Time:
-            sendSysexPatchRhythmChange1Byte(0x2f, uint8_t(aenv4TimeSlider.getValue()));
-            tone->tvaEnvTime4 = uint8_t(aenv4TimeSlider.getValue());
-            break;
-        case dry:
-            sendSysexPatchRhythmChange1Byte(0x30, uint8_t(drySlider.getValue()));
-            tone->drySend = uint8_t(drySlider.getValue());
-            break;
-        case reverb:
-            sendSysexPatchRhythmChange1Byte(0x31, uint8_t(reverbSlider.getValue()));
-            tone->reverbSend = uint8_t(reverbSlider.getValue());
-            break;
-        case chorus:
-            sendSysexPatchRhythmChange1Byte(0x32, uint8_t(chorusSlider.getValue()));
-            tone->chorusSend = uint8_t(chorusSlider.getValue());
-            break;
-        default:
-            break;
+    case waveform:
+        sendSysexPatchRhythmChange2Byte(0x01, uint8_t(waveformComboBox.getSelectedItemIndex()));
+        tone->waveNumber = uint8_t(waveformComboBox.getSelectedItemIndex());
+        break;
+    case pitchCoarse:
+        sendSysexPatchRhythmChange1Byte(0x04, uint8_t(pitchCoarseSlider.getValue() + 64));
+        tone->pitchCoarse = uint8_t(pitchCoarseSlider.getValue() + 64);
+        break;
+    case mute:
+        sendSysexPatchRhythmChange1Byte(0x05, uint8_t(muteSlider.getValue()));
+        tone->muteGroup = uint8_t((uint8_t(muteSlider.getValue()) << 0) + (envModeComboBox.getSelectedItemIndex() << 5));
+        break;
+    case pitchFine:
+        sendSysexPatchRhythmChange1Byte(0x07, uint8_t(pitchFineSlider.getValue() + 64));
+        tone->pitchFine = uint8_t(pitchFineSlider.getValue());
+        break;
+    case bendRange:
+        sendSysexPatchRhythmChange1Byte(0x09, uint8_t(bendRangeSlider.getValue()));
+        tone->bendRange = uint8_t(penvTimeSensComboBox.getSelectedItemIndex() + (uint8_t(bendRangeSlider.getValue()) << 4));
+        break;
+    case penvLevSens:
+        sendSysexPatchRhythmChange1Byte(0x0a, uint8_t(penvLevSensSlider.getValue() + 64));
+        tone->tvpVelocity = uint8_t(penvLevSensSlider.getValue());
+        break;
+    case penvDepth:
+        sendSysexPatchRhythmChange1Byte(0x0c, uint8_t(penvDepthSlider.getValue() + 64));
+        tone->tvpEnvDepth = uint8_t(penvDepthSlider.getValue());
+        break;
+    case penv1Time:
+        sendSysexPatchRhythmChange1Byte(0x0d, uint8_t(penv1TimeSlider.getValue()));
+        tone->tvpEnvTime1 = uint8_t(penv1TimeSlider.getValue());
+        break;
+    case penv1Level:
+        sendSysexPatchRhythmChange1Byte(0x0e, uint8_t(penv1LevelSlider.getValue() + 64));
+        tone->tvpEnvLevel1 = uint8_t(penv1LevelSlider.getValue());
+        break;
+    case penv2Time:
+        sendSysexPatchRhythmChange1Byte(0x0f, uint8_t(penv2TimeSlider.getValue()));
+        tone->tvpEnvTime2 = uint8_t(penv2TimeSlider.getValue());
+        break;
+    case penv2Level:
+        sendSysexPatchRhythmChange1Byte(0x10, uint8_t(penv2LevelSlider.getValue() + 64));
+        tone->tvpEnvLevel2 = uint8_t(penv2LevelSlider.getValue());
+        break;
+    case penv3Time:
+        sendSysexPatchRhythmChange1Byte(0x11, uint8_t(penv3TimeSlider.getValue()));
+        tone->tvpEnvTime3 = uint8_t(penv3TimeSlider.getValue());
+        break;
+    case penv3Level:
+        sendSysexPatchRhythmChange1Byte(0x12, uint8_t(penv3LevelSlider.getValue() + 64));
+        tone->tvpEnvLevel3 = uint8_t(penv3LevelSlider.getValue());
+        break;
+    case penv4Time:
+        sendSysexPatchRhythmChange1Byte(0x13, uint8_t(penv4TimeSlider.getValue()));
+        tone->tvpEnvTime4 = uint8_t(penv4TimeSlider.getValue());
+        break;
+    case penv4Level:
+        sendSysexPatchRhythmChange1Byte(0x14, uint8_t(penv4LevelSlider.getValue() + 64));
+        tone->tvpEnvLevel4 = uint8_t(penv4LevelSlider.getValue());
+        break;
+    case filterCutoff:
+        sendSysexPatchRhythmChange1Byte(0x16, uint8_t(filterCutoffSlider.getValue()));
+        tone->tvfCutoff = uint8_t(filterCutoffSlider.getValue());
+        break;
+    case filterReso:
+        sendSysexPatchRhythmChange1Byte(0x17, uint8_t(filterResoSlider.getValue()));
+        tone->tvfResonance = uint8_t(filterResoSlider.getValue() + (filterResoModeComboBox.getSelectedItemIndex() << 7));
+        break;
+    case fenvLevSens:
+        sendSysexPatchRhythmChange1Byte(0x19, uint8_t(fenvLevSensSlider.getValue() + 64));
+        tone->tvfVelocity = uint8_t(fenvLevSensSlider.getValue());
+        break;
+    case fenvDepth:
+        sendSysexPatchRhythmChange1Byte(0x1b, uint8_t(fenvDepthSlider.getValue() + 64));
+        tone->tvfEnvDepth = uint8_t(fenvDepthSlider.getValue());
+        break;
+    case fenv1Time:
+        sendSysexPatchRhythmChange1Byte(0x1c, uint8_t(fenv1TimeSlider.getValue()));
+        tone->tvfEnvTime1 = uint8_t(fenv1TimeSlider.getValue());
+        break;
+    case fenv1Level:
+        sendSysexPatchRhythmChange1Byte(0x1d, uint8_t(fenv1LevelSlider.getValue()));
+        tone->tvfEnvLevel1 = uint8_t(fenv1LevelSlider.getValue());
+        break;
+    case fenv2Time:
+        sendSysexPatchRhythmChange1Byte(0x1e, uint8_t(fenv2TimeSlider.getValue()));
+        tone->tvfEnvTime2 = uint8_t(fenv2TimeSlider.getValue());
+        break;
+    case fenv2Level:
+        sendSysexPatchRhythmChange1Byte(0x1f, uint8_t(fenv2LevelSlider.getValue()));
+        tone->tvfEnvLevel2 = uint8_t(fenv2LevelSlider.getValue());
+        break;
+    case fenv3Time:
+        sendSysexPatchRhythmChange1Byte(0x20, uint8_t(fenv3TimeSlider.getValue()));
+        tone->tvfEnvTime3 = uint8_t(fenv3TimeSlider.getValue());
+        break;
+    case fenv3Level:
+        sendSysexPatchRhythmChange1Byte(0x21, uint8_t(fenv3LevelSlider.getValue()));
+        tone->tvfEnvLevel3 = uint8_t(fenv3LevelSlider.getValue());
+        break;
+    case fenv4Time:
+        sendSysexPatchRhythmChange1Byte(0x22, uint8_t(fenv4TimeSlider.getValue()));
+        tone->tvfEnvTime4 = uint8_t(fenv4TimeSlider.getValue());
+        break;
+    case fenv4Level:
+        sendSysexPatchRhythmChange1Byte(0x23, uint8_t(fenv4LevelSlider.getValue()));
+        tone->tvfEnvLevel4 = uint8_t(fenv4LevelSlider.getValue());
+        break;
+    case level:
+        sendSysexPatchRhythmChange1Byte(0x24, uint8_t(levelSlider.getValue()));
+        tone->tvaLevel = uint8_t(levelSlider.getValue());
+        break;
+    case pan:
+        sendSysexPatchRhythmChange2Byte(0x25, uint8_t(panSlider.getValue() + 64));
+        tone->tvaPan = uint8_t(panSlider.getValue() + 64);
+        break;
+    case aenvLevSens:
+        sendSysexPatchRhythmChange1Byte(0x27, uint8_t(aenvLevSensSlider.getValue() + 64));
+        tone->tvaVelocity = uint8_t(aenvLevSensSlider.getValue());
+        break;
+    case aenv1Time:
+        sendSysexPatchRhythmChange1Byte(0x29, uint8_t(aenv1TimeSlider.getValue()));
+        tone->tvaEnvTime1 = uint8_t(aenv1TimeSlider.getValue());
+        break;
+    case aenv1Level:
+        sendSysexPatchRhythmChange1Byte(0x2a, uint8_t(aenv1LevelSlider.getValue()));
+        tone->tvaEnvLevel1 = uint8_t(aenv1LevelSlider.getValue());
+        break;
+    case aenv2Time:
+        sendSysexPatchRhythmChange1Byte(0x2b, uint8_t(aenv2TimeSlider.getValue()));
+        tone->tvaEnvTime2 = uint8_t(aenv2TimeSlider.getValue());
+        break;
+    case aenv2Level:
+        sendSysexPatchRhythmChange1Byte(0x2c, uint8_t(aenv2LevelSlider.getValue()));
+        tone->tvaEnvLevel2 = uint8_t(aenv2LevelSlider.getValue());
+        break;
+    case aenv3Time:
+        sendSysexPatchRhythmChange1Byte(0x2d, uint8_t(aenv3TimeSlider.getValue()));
+        tone->tvaEnvTime3 = uint8_t(aenv3TimeSlider.getValue());
+        break;
+    case aenv3Level:
+        sendSysexPatchRhythmChange1Byte(0x2e, uint8_t(aenv3LevelSlider.getValue()));
+        tone->tvaEnvLevel3 = uint8_t(aenv3LevelSlider.getValue());
+        break;
+    case aenv4Time:
+        sendSysexPatchRhythmChange1Byte(0x2f, uint8_t(aenv4TimeSlider.getValue()));
+        tone->tvaEnvTime4 = uint8_t(aenv4TimeSlider.getValue());
+        break;
+    case dry:
+        sendSysexPatchRhythmChange1Byte(0x30, uint8_t(drySlider.getValue()));
+        tone->drySend = uint8_t(drySlider.getValue());
+        break;
+    case reverb:
+        sendSysexPatchRhythmChange1Byte(0x31, uint8_t(reverbSlider.getValue()));
+        tone->reverbSend = uint8_t(reverbSlider.getValue());
+        break;
+    case chorus:
+        sendSysexPatchRhythmChange1Byte(0x32, uint8_t(chorusSlider.getValue()));
+        tone->chorusSend = uint8_t(chorusSlider.getValue());
+        break;
+    default:
+        break;
     }
 }
 
@@ -683,17 +699,18 @@ void EditRhythmTab::buttonClicked(juce::Button* button)
     {
         id = i->getID();
     }
-    
+
     Rhythm* rhythm = (Rhythm*)processor.status.drums;
     RhythmTone* tone = &rhythm->tones[toneCount];
-    switch(id)
+
+    switch (id)
     {
-        case toneSwitch:
-            sendSysexPatchRhythmChange1Byte(0x03, toneSwitchToggle.getToggleStateValue() == 1 ? 0x01 : 0x00);
-            tone->flags = uint8_t(waveGroupComboBox.getSelectedItemIndex() + (toneSwitchToggle.getToggleState() << 7));
-            break;
-        default:
-            break;
+    case toneSwitch:
+        sendSysexPatchRhythmChange1Byte(0x03, toneSwitchToggle.getToggleStateValue() == 1 ? 0x01 : 0x00);
+        tone->flags = uint8_t(waveGroupComboBox.getSelectedItemIndex() + (toneSwitchToggle.getToggleState() << 7));
+        break;
+    default:
+        break;
     }
 }
 
@@ -705,53 +722,58 @@ void EditRhythmTab::comboBoxChanged(juce::ComboBox* comboBox)
     {
         id = i->getID();
     }
-    
+
     Rhythm* rhythm = (Rhythm*)processor.status.drums;
     RhythmTone* tone = &rhythm->tones[toneCount];
-    switch(id)
+
+    switch (id)
     {
-        case waveGroup:
-            updateWaveformComboBox(waveformComboBox);
-            sendSysexPatchRhythmChange1Byte(0x00, uint8_t(waveGroupComboBox.getSelectedItemIndex()));
-            tone->flags = uint8_t(waveGroupComboBox.getSelectedItemIndex() + (toneSwitchToggle.getToggleState() << 7));
-            break;
-        case waveform:
-            sendSysexPatchRhythmChange2Byte(0x01, uint8_t(waveformComboBox.getSelectedItemIndex()));
-            tone->waveNumber = uint8_t(waveformComboBox.getSelectedItemIndex());
-            break;
-        case envMode:
-            sendSysexPatchRhythmChange1Byte(0x06, uint8_t(envModeComboBox.getSelectedItemIndex()));
-            tone->muteGroup = uint8_t((uint8_t(muteSlider.getValue()) << 0) + (envModeComboBox.getSelectedItemIndex() << 5));
-            break;
-        case pitchRandom:
-            sendSysexPatchRhythmChange1Byte(0x08, uint8_t(pitchRandomComboBox.getSelectedItemIndex()));
-            tone->pitchRandom = uint8_t(pitchRandomComboBox.getSelectedItemIndex());
-            break;
-        case penvTimeSens:
-            sendSysexPatchRhythmChange1Byte(0x0b, uint8_t(penvTimeSensComboBox.getSelectedItemIndex()));
-            tone->bendRange = uint8_t(penvTimeSensComboBox.getSelectedItemIndex() + (uint8_t(bendRangeSlider.getValue()) << 4));
-            break;
-        case filterMode:
-            sendSysexPatchRhythmChange1Byte(0x15, uint8_t(filterModeComboBox.getSelectedItemIndex()));
-            tone->tvfTimeVelLpfHpf = uint8_t(fenvTimeSensComboBox.getSelectedItemIndex() + (filterModeComboBox.getSelectedItemIndex() << 4));
-            break;
-        case filterResoMode:
-            sendSysexPatchRhythmChange1Byte(0x18, uint8_t(filterResoModeComboBox.getSelectedItemIndex()));
-            tone->tvfResonance = uint8_t(filterResoSlider.getValue() + (filterResoModeComboBox.getSelectedItemIndex() << 7));
-            break;
-        case fenvTimeSens:
-            sendSysexPatchRhythmChange1Byte(0x1a, uint8_t(fenvTimeSensComboBox.getSelectedItemIndex()));
-            tone->tvfTimeVelLpfHpf = uint8_t(fenvTimeSensComboBox.getSelectedItemIndex() + (filterModeComboBox.getSelectedItemIndex() << 4));
-            break;
-        case aenvTimeSens:
-            sendSysexPatchRhythmChange1Byte(0x28, uint8_t(aenvTimeSensComboBox.getSelectedItemIndex()));
-            tone->tvaTimeVelocity = uint8_t(aenvTimeSensComboBox.getSelectedItemIndex());
-            break;
-        case output:
-            sendSysexPatchRhythmChange1Byte(0x33, uint8_t(outputComboBox.getSelectedItemIndex()));
-            break;
-        default:
-            break;
+    case toneSelect:
+        toneCount = uint8_t(selectKeyComboBox.getSelectedItemIndex());
+        updateValues();
+        break;
+    case waveGroup:
+        updateWaveformComboBox(waveformComboBox);
+        sendSysexPatchRhythmChange1Byte(0x00, uint8_t(waveGroupComboBox.getSelectedItemIndex()));
+        tone->flags = uint8_t(waveGroupComboBox.getSelectedItemIndex() + (toneSwitchToggle.getToggleState() << 7));
+        break;
+    case waveform:
+        sendSysexPatchRhythmChange2Byte(0x01, uint8_t(waveformComboBox.getSelectedItemIndex()));
+        tone->waveNumber = uint8_t(waveformComboBox.getSelectedItemIndex());
+        break;
+    case envMode:
+        sendSysexPatchRhythmChange1Byte(0x06, uint8_t(envModeComboBox.getSelectedItemIndex()));
+        tone->muteGroup = uint8_t((uint8_t(muteSlider.getValue()) << 0) + (envModeComboBox.getSelectedItemIndex() << 5));
+        break;
+    case pitchRandom:
+        sendSysexPatchRhythmChange1Byte(0x08, uint8_t(pitchRandomComboBox.getSelectedItemIndex()));
+        tone->pitchRandom = uint8_t(pitchRandomComboBox.getSelectedItemIndex());
+        break;
+    case penvTimeSens:
+        sendSysexPatchRhythmChange1Byte(0x0b, uint8_t(penvTimeSensComboBox.getSelectedItemIndex()));
+        tone->bendRange = uint8_t(penvTimeSensComboBox.getSelectedItemIndex() + (uint8_t(bendRangeSlider.getValue()) << 4));
+        break;
+    case filterMode:
+        sendSysexPatchRhythmChange1Byte(0x15, uint8_t(filterModeComboBox.getSelectedItemIndex()));
+        tone->tvfTimeVelLpfHpf = uint8_t(fenvTimeSensComboBox.getSelectedItemIndex() + (filterModeComboBox.getSelectedItemIndex() << 4));
+        break;
+    case filterResoMode:
+        sendSysexPatchRhythmChange1Byte(0x18, uint8_t(filterResoModeComboBox.getSelectedItemIndex()));
+        tone->tvfResonance = uint8_t(filterResoSlider.getValue() + (filterResoModeComboBox.getSelectedItemIndex() << 7));
+        break;
+    case fenvTimeSens:
+        sendSysexPatchRhythmChange1Byte(0x1a, uint8_t(fenvTimeSensComboBox.getSelectedItemIndex()));
+        tone->tvfTimeVelLpfHpf = uint8_t(fenvTimeSensComboBox.getSelectedItemIndex() + (filterModeComboBox.getSelectedItemIndex() << 4));
+        break;
+    case aenvTimeSens:
+        sendSysexPatchRhythmChange1Byte(0x28, uint8_t(aenvTimeSensComboBox.getSelectedItemIndex()));
+        tone->tvaTimeVelocity = uint8_t(aenvTimeSensComboBox.getSelectedItemIndex());
+        break;
+    case output:
+        sendSysexPatchRhythmChange1Byte(0x33, uint8_t(outputComboBox.getSelectedItemIndex()));
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/ui/EditRhythmTab.h
+++ b/Source/ui/EditRhythmTab.h
@@ -14,8 +14,6 @@
 #include <JuceHeader.h>
 
 #include "../PluginProcessor.h"
-#include "../PluginEditor.h"
-#include "../dataStructures.h"
 
 #include "widgets/Button.h"
 #include "widgets/Menu.h"
@@ -26,19 +24,19 @@ class VirtualJVEditor;
 //==============================================================================
 
 class EditRhythmTab : public juce::Component,
-                    public juce::Slider::Listener,
-                    public juce::Button::Listener,
-                    public juce::ComboBox::Listener
+    public juce::Slider::Listener,
+    public juce::Button::Listener,
+    public juce::ComboBox::Listener
 {
 public:
-    EditRhythmTab(VirtualJVProcessor &, VirtualJVEditor *);
+    EditRhythmTab(VirtualJVProcessor&, VirtualJVEditor*);
     ~EditRhythmTab() override;
 
     void resized() override;
-    void sliderValueChanged(juce::Slider *) override;
-    void buttonClicked(juce::Button *) override;
+    void sliderValueChanged(juce::Slider*) override;
+    void buttonClicked(juce::Button*) override;
     void buttonStateChanged(juce::Button*) override {}
-    void comboBoxChanged(juce::ComboBox *) override;
+    void comboBoxChanged(juce::ComboBox*) override;
 
     void updateValues();
 
@@ -48,179 +46,179 @@ public:
 private:
     enum EditRhythmWidgets
     {
-        toneSelect          = 300U,
-        waveGroup           = 301U,
-        waveform            = 302U,
-        toneSwitch          = 303U,
-        mute                = 304U,
-        envMode             = 305U,
-        bendRange           = 306U,
+        toneSelect = 300U,
+        waveGroup = 301U,
+        waveform = 302U,
+        toneSwitch = 303U,
+        mute = 304U,
+        envMode = 305U,
+        bendRange = 306U,
 
-        pitchCoarse         = 310U,
-        pitchFine           = 311U,
-        pitchRandom         = 312U,
-        DelayFeedback       = 313U,
-        penvLevSens         = 314U,
-        penvTimeSens        = 315U,
-        penvDepth           = 316U,
-        
-        penv1Time           = 320U,
-        penv1Level          = 321U,
-        penv2Time           = 322U,
-        penv2Level          = 323U,
-        penv3Time           = 324U,
-        penv3Level          = 325U,
-        penv4Time           = 326U,
-        penv4Level          = 327U,
-        
-        filterMode          = 330U,
-        filterCutoff        = 331U,
-        filterReso          = 332U,
-        filterResoMode      = 333U,
-        fenvLevSens         = 334U,
-        fenvTimeSens        = 335U,
-        fenvDepth           = 336U,
-        
-        fenv1Time           = 340U,
-        fenv1Level          = 341U,
-        fenv2Time           = 342U,
-        fenv2Level          = 343U,
-        fenv3Time           = 344U,
-        fenv3Level          = 345U,
-        fenv4Time           = 346U,
-        fenv4Level          = 347U,
-        
-        level               = 350U,
-        pan                 = 351U,
-        aenvLevSens         = 352U,
-        aenvTimeSens        = 353U,
-        
-        aenv1Time           = 360U,
-        aenv1Level          = 361U,
-        aenv2Time           = 362U,
-        aenv2Level          = 363U,
-        aenv3Time           = 364U,
-        aenv3Level          = 365U,
-        aenv4Time           = 366U,
-        
-        dry                 = 370U,
-        reverb              = 371U,
-        chorus              = 372U,
-        output              = 373U
+        pitchCoarse = 310U,
+        pitchFine = 311U,
+        pitchRandom = 312U,
+        DelayFeedback = 313U,
+        penvLevSens = 314U,
+        penvTimeSens = 315U,
+        penvDepth = 316U,
+
+        penv1Time = 320U,
+        penv1Level = 321U,
+        penv2Time = 322U,
+        penv2Level = 323U,
+        penv3Time = 324U,
+        penv3Level = 325U,
+        penv4Time = 326U,
+        penv4Level = 327U,
+
+        filterMode = 330U,
+        filterCutoff = 331U,
+        filterReso = 332U,
+        filterResoMode = 333U,
+        fenvLevSens = 334U,
+        fenvTimeSens = 335U,
+        fenvDepth = 336U,
+
+        fenv1Time = 340U,
+        fenv1Level = 341U,
+        fenv2Time = 342U,
+        fenv2Level = 343U,
+        fenv3Time = 344U,
+        fenv3Level = 345U,
+        fenv4Time = 346U,
+        fenv4Level = 347U,
+
+        level = 350U,
+        pan = 351U,
+        aenvLevSens = 352U,
+        aenvTimeSens = 353U,
+
+        aenv1Time = 360U,
+        aenv1Level = 361U,
+        aenv2Time = 362U,
+        aenv2Level = 363U,
+        aenv3Time = 364U,
+        aenv3Level = 365U,
+        aenv4Time = 366U,
+
+        dry = 370U,
+        reverb = 371U,
+        chorus = 372U,
+        output = 373U
     };
-    
-    void addMenuEntriesFromArray(Menu &menu, const std::vector<std::string> &array);
-    void updateWaveformComboBox(Menu &wfMenu);
 
-    VirtualJVProcessor &processor;
-    VirtualJVEditor *editor;
-    Slider toneSlider {toneSelect, 36, 96, 1};
+    void addMenuEntriesFromArray(Menu& menu, const std::vector<std::string>& array);
+    void updateWaveformComboBox(Menu& wfMenu);
+
+    VirtualJVProcessor& processor;
+    VirtualJVEditor* editor;
+    Menu selectKeyComboBox{ toneSelect };
     juce::Label toneLabel;
     uint8_t toneCount;
 
-    Menu waveGroupComboBox { waveGroup };
+    Menu waveGroupComboBox{ waveGroup };
     juce::Label waveGroupLabel;
-    Menu waveformComboBox { waveform };
+    Menu waveformComboBox{ waveform };
     juce::Label waveformLabel;
-    Button toneSwitchToggle { toneSwitch , "Enable" };
+    Button toneSwitchToggle{ toneSwitch , "Enable" };
     juce::Label toneSwitchLabel;
 
-    Slider muteSlider {mute, 0, 31, 1};
+    Slider muteSlider{ mute, 0, 31, 1 };
     juce::Label muteLabel;
-    Menu envModeComboBox { envMode };
+    Menu envModeComboBox{ envMode };
     juce::Label envModeLabel;
-    Slider bendRangeSlider { bendRange, 0, 12, 1 };
+    Slider bendRangeSlider{ bendRange, 0, 12, 1 };
     juce::Label bendRangeLabel;
 
-    Slider pitchCoarseSlider { pitchCoarse, -48, 48, 1 };
+    Slider pitchCoarseSlider{ pitchCoarse, -48, 48, 1 };
     juce::Label pitchCoarseLabel;
-    Slider pitchFineSlider { pitchFine, -50, 50, 1 };
+    Slider pitchFineSlider{ pitchFine, -50, 50, 1 };
     juce::Label pitchFineLabel;
-    Menu pitchRandomComboBox { pitchRandom };
+    Menu pitchRandomComboBox{ pitchRandom };
     juce::Label pitchRandomLabel;
-    Slider penvLevSensSlider { penvLevSens, -12, 12, 1 };
+    Slider penvLevSensSlider{ penvLevSens, -12, 12, 1 };
     juce::Label penvLevSensLabel;
-    Menu penvTimeSensComboBox { penvTimeSens };
+    Menu penvTimeSensComboBox{ penvTimeSens };
     juce::Label penvTimeSensLabel;
-    Slider penvDepthSlider { penvDepth, -12, 12, 1 };
+    Slider penvDepthSlider{ penvDepth, -12, 12, 1 };
     juce::Label penvDepthLabel;
-    Slider penv1TimeSlider { penv1Time, 0, 127, 1 };
+    Slider penv1TimeSlider{ penv1Time, 0, 127, 1 };
     juce::Label penv1TimeLabel;
-    Slider penv1LevelSlider { penv1Level, -63, 63, 1 };
+    Slider penv1LevelSlider{ penv1Level, -63, 63, 1 };
     juce::Label penv1LevelLabel;
-    Slider penv2TimeSlider { penv2Time, 0, 127, 1 };
+    Slider penv2TimeSlider{ penv2Time, 0, 127, 1 };
     juce::Label penv2TimeLabel;
-    Slider penv2LevelSlider { penv2Level, -63, 63, 1 };
+    Slider penv2LevelSlider{ penv2Level, -63, 63, 1 };
     juce::Label penv2LevelLabel;
-    Slider penv3TimeSlider { penv3Time, 0, 127, 1 };
+    Slider penv3TimeSlider{ penv3Time, 0, 127, 1 };
     juce::Label penv3TimeLabel;
-    Slider penv3LevelSlider { penv3Level, -63, 63, 1 };
+    Slider penv3LevelSlider{ penv3Level, -63, 63, 1 };
     juce::Label penv3LevelLabel;
-    Slider penv4TimeSlider { penv4Time, 0, 127, 1 };
+    Slider penv4TimeSlider{ penv4Time, 0, 127, 1 };
     juce::Label penv4TimeLabel;
-    Slider penv4LevelSlider { penv4Level, -63, 63, 1 };
+    Slider penv4LevelSlider{ penv4Level, -63, 63, 1 };
     juce::Label penv4LevelLabel;
 
-    Menu filterModeComboBox { filterMode };
+    Menu filterModeComboBox{ filterMode };
     juce::Label filterModeLabel;
-    Slider filterCutoffSlider { filterCutoff, 0, 127, 1 };
+    Slider filterCutoffSlider{ filterCutoff, 0, 127, 1 };
     juce::Label filterCutoffLabel;
-    Slider filterResoSlider { filterReso, 0, 127, 1 };
+    Slider filterResoSlider{ filterReso, 0, 127, 1 };
     juce::Label filterResoLabel;
-    Menu filterResoModeComboBox { filterReso };
-    Slider fenvLevSensSlider { fenvLevSens, -63, 63, 1 };
+    Menu filterResoModeComboBox{ filterReso };
+    Slider fenvLevSensSlider{ fenvLevSens, -63, 63, 1 };
     juce::Label fenvLevSensLabel;
-    Menu fenvTimeSensComboBox { fenvTimeSens };
+    Menu fenvTimeSensComboBox{ fenvTimeSens };
     juce::Label fenvTimeSensLabel;
-    Slider fenvDepthSlider { fenvDepth, 0, 127, 1 };
+    Slider fenvDepthSlider{ fenvDepth, 0, 127, 1 };
     juce::Label fenvDepthLabel;
-    Slider fenv1TimeSlider { fenv1Time, 0, 127, 1 };
+    Slider fenv1TimeSlider{ fenv1Time, 0, 127, 1 };
     juce::Label fenv1TimeLabel;
-    Slider fenv1LevelSlider { fenv1Level, 0, 127, 1 };
+    Slider fenv1LevelSlider{ fenv1Level, 0, 127, 1 };
     juce::Label fenv1LevelLabel;
-    Slider fenv2TimeSlider { fenv2Time, 0, 127, 1 };
+    Slider fenv2TimeSlider{ fenv2Time, 0, 127, 1 };
     juce::Label fenv2TimeLabel;
-    Slider fenv2LevelSlider { fenv2Level, 0, 127, 1 };
+    Slider fenv2LevelSlider{ fenv2Level, 0, 127, 1 };
     juce::Label fenv2LevelLabel;
-    Slider fenv3TimeSlider { fenv3Time, 0, 127, 1 };
+    Slider fenv3TimeSlider{ fenv3Time, 0, 127, 1 };
     juce::Label fenv3TimeLabel;
-    Slider fenv3LevelSlider { fenv3Level, 0, 127, 1 };
+    Slider fenv3LevelSlider{ fenv3Level, 0, 127, 1 };
     juce::Label fenv3LevelLabel;
-    Slider fenv4TimeSlider { fenv4Time, 0, 127, 1 };
+    Slider fenv4TimeSlider{ fenv4Time, 0, 127, 1 };
     juce::Label fenv4TimeLabel;
-    Slider fenv4LevelSlider { fenv4Level, 0, 127, 1 };
+    Slider fenv4LevelSlider{ fenv4Level, 0, 127, 1 };
     juce::Label fenv4LevelLabel;
 
-    Slider levelSlider { level, 0, 127, 1 };
+    Slider levelSlider{ level, 0, 127, 1 };
     juce::Label levelLabel;
-    Slider panSlider { pan, -64, 64, 1 };
+    Slider panSlider{ pan, -64, 64, 1 };
     juce::Label panLabel;
-    Slider aenvLevSensSlider { aenvLevSens, -63, 63, 1 };
+    Slider aenvLevSensSlider{ aenvLevSens, -63, 63, 1 };
     juce::Label aenvLevSensLabel;
-    Menu aenvTimeSensComboBox { aenvTimeSens };
+    Menu aenvTimeSensComboBox{ aenvTimeSens };
     juce::Label aenvTimeSensLabel;
-    Slider aenv1TimeSlider { aenv1Time, 0, 127, 1 };
+    Slider aenv1TimeSlider{ aenv1Time, 0, 127, 1 };
     juce::Label aenv1TimeLabel;
-    Slider aenv1LevelSlider { aenv1Level, 0, 127, 1 };
+    Slider aenv1LevelSlider{ aenv1Level, 0, 127, 1 };
     juce::Label aenv1LevelLabel;
-    Slider aenv2TimeSlider { aenv2Time, 0, 127, 1 };
+    Slider aenv2TimeSlider{ aenv2Time, 0, 127, 1 };
     juce::Label aenv2TimeLabel;
-    Slider aenv2LevelSlider { aenv2Level, 0, 127, 1 };
+    Slider aenv2LevelSlider{ aenv2Level, 0, 127, 1 };
     juce::Label aenv2LevelLabel;
-    Slider aenv3TimeSlider { aenv3Time, 0, 127, 1 };
+    Slider aenv3TimeSlider{ aenv3Time, 0, 127, 1 };
     juce::Label aenv3TimeLabel;
-    Slider aenv3LevelSlider { aenv3Level, 0, 127, 1 };
+    Slider aenv3LevelSlider{ aenv3Level, 0, 127, 1 };
     juce::Label aenv3LevelLabel;
-    Slider aenv4TimeSlider { aenv4Time, 0, 127, 1 };
+    Slider aenv4TimeSlider{ aenv4Time, 0, 127, 1 };
     juce::Label aenv4TimeLabel;
 
-    Slider drySlider { dry, 0, 127, 1 };
+    Slider drySlider{ dry, 0, 127, 1 };
     juce::Label dryLabel;
-    Slider reverbSlider { reverb, 0, 127, 1 };
+    Slider reverbSlider{ reverb, 0, 127, 1 };
     juce::Label reverbLabel;
-    Slider chorusSlider { chorus, 0, 127, 1 };
+    Slider chorusSlider{ chorus, 0, 127, 1 };
     juce::Label chorusLabel;
-    Menu outputComboBox { output };
+    Menu outputComboBox{ output };
     juce::Label outputLabel;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EditRhythmTab)

--- a/Source/ui/EditToneTab.cpp
+++ b/Source/ui/EditToneTab.cpp
@@ -10,7 +10,9 @@
 
 #include <JuceHeader.h>
 #include <algorithm>
+
 #include "EditToneTab.h"
+
 #include "../PluginEditor.h"
 #include "../dataStructures.h"
 

--- a/Source/ui/EditToneTab.h
+++ b/Source/ui/EditToneTab.h
@@ -10,8 +10,9 @@
 
 #pragma once
 
-#include "../PluginProcessor.h"
 #include <JuceHeader.h>
+
+#include "../PluginProcessor.h"
 
 class VirtualJVEditor;
 


### PR DESCRIPTION
Show/Hide Tone 1-4 vs Rhythm Set tabs depending on which preset is loaded.

Common page second column of controls also gets hidden if a rhythm set is loaded.

Tone Key parameter renamed to Key and changed to dropdown menu.

Reordered 880 Factory banks, so that internal A and B go first, then User, then rhythm sets.

Fix build issues due to incorrect file imports.