### PR TITLE
Disregard MIDI events coming from JUCE larger than 32 bytes

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -316,35 +316,40 @@ bool VirtualJVProcessor::isBusesLayoutSupported(
   return true;
 }
 
-void VirtualJVProcessor::processBlock(juce::AudioBuffer<float> &buffer,
-                                            juce::MidiBuffer &midiMessages) {
+void VirtualJVProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuffer &midiMessages)
+{
   mcuLock.enter();
 
-  for (const auto metadata : midiMessages) {
+  for (const auto metadata : midiMessages)
+  {
     auto message = metadata.getMessage();
-    if (status.isDrums)
-      message.setChannel(10);
-    else
-      message.setChannel(1);
+
+    message.setChannel(status.isDrums ? 10 : 1);
+
     int samplePos = int(((double)metadata.samplePosition / getSampleRate()) * 64000.0);
-    mcu->enqueueMidiSC55(message.getRawData(), message.getRawDataSize(),
-                         samplePos);
+
+    mcu->enqueueMidiSC55(message.getRawData(), message.getRawDataSize(), samplePos);
   }
 
   juce::ScopedNoDenormals noDenormals;
+
   auto totalNumInputChannels = getTotalNumInputChannels();
   auto totalNumOutputChannels = getTotalNumOutputChannels();
 
   for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
+  {
     buffer.clear(i, 0, buffer.getNumSamples());
+  }
 
-  if (!loaded) {
+  if (!loaded)
+  {
     mcuLock.exit();
     return;
   }
 
   float *channelDataL = buffer.getWritePointer(0);
   float *channelDataR = buffer.getWritePointer(1);
+
   mcu->updateSC55WithSampleRate(channelDataL, channelDataR,
                                 buffer.getNumSamples(), (int)getSampleRate());
 

--- a/Source/emulator/mcu.cpp
+++ b/Source/emulator/mcu.cpp
@@ -1378,6 +1378,11 @@ void MCU::postMidiSC55(const uint8_t* message, int length) {
 }
 
 void MCU::enqueueMidiSC55(const uint8_t* message, int length, int samplePos) {
+    if (length >= MIDI_EVENT_DATA_SIZE)
+    {
+        return;
+    }
+
     MidiEvent event = {0};
     event.length = length;
     event.samplePos = samplePos;

--- a/Source/emulator/mcu.h
+++ b/Source/emulator/mcu.h
@@ -288,6 +288,8 @@ static const int audio_page_size = 512;
 
 static const int ROM_SET_N_FILES = 6;
 
+static constexpr int MIDI_EVENT_DATA_SIZE = 32;
+
 struct MCU {
     int romset = 0;
 
@@ -374,7 +376,7 @@ struct MCU {
     double samplesError = 0;
     
     struct MidiEvent {
-        uint8_t data[32];
+        uint8_t data[MIDI_EVENT_DATA_SIZE];
         int length;
         int samplePos;
         bool processed;


### PR DESCRIPTION
This should hopefully fix crashing on load in Logic.

Maybe think about increasing this data buffer size later, if we start dropping some actually important messages (this one was Logic's tuning system message, size was 408 bytes...).