### PR TITLE
Remember selected ROM when closing the GUI

### DIFF
--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -89,7 +89,8 @@ public:
         uint8_t drums[0xa7c] = {0};
 
         int selectedTab{0};
-        uint8_t selectedRom{0};
+        int selectedRom{-1};
+        int selectedPatch{-1};
     };
 
     DataToSave status;

--- a/Source/ui/PatchBrowser.cpp
+++ b/Source/ui/PatchBrowser.cpp
@@ -13,12 +13,13 @@
 
 //==============================================================================
 PatchBrowser::PatchBrowser(VirtualJVProcessor &p)
-    : processor(p), categoriesListModel(),
-      categoriesListBox("Categories", &categoriesListModel) {
+    : processor(p), categoriesListModel(), categoriesListBox("Categories", &categoriesListModel)
+{
   categoriesListBox.setRowHeight(34);
   addAndMakeVisible(categoriesListBox);
 
-  for (int i = 0; i < columns; i++) {
+  for (int i = 0; i < columns; i++)
+  {
     patchesListModels[i] =
         new PatchesListModel(rowPerColumn * i, rowPerColumn * (i + 1), this,
                              &categoriesListBox, &categoriesListModel);
@@ -28,19 +29,50 @@ PatchBrowser::PatchBrowser(VirtualJVProcessor &p)
     patchesListBoxes[i]->setRowHeight(17);
     addAndMakeVisible(*patchesListBoxes[i]);
   }
+
+  if (processor.loaded)
+  {
+    if (processor.status.selectedRom < 0)
+    {
+      processor.status.selectedRom = 0;
+    }
+
+    categoriesListBox.selectRow(processor.status.selectedRom);
+
+    /* this doesn't seem to work for some reason
+    const auto col = processor.status.selectedPatch / rowPerColumn;
+    const auto row = processor.status.selectedPatch % rowPerColumn;
+
+    patchesListBoxes[col]->selectRow(row);
+    */
+  }
 }
 
-PatchBrowser::~PatchBrowser() {
-  for (int i = 0; i < columns; i++) {
+PatchBrowser::~PatchBrowser()
+{
+  processor.status.selectedRom = categoriesListBox.getSelectedRow();
+
+  for (int i = 0; i < columns; i++)
+  {
+    if (patchesListBoxes[i]->getSelectedRow() > -1)
+    {
+      processor.status.selectedPatch = (i * rowPerColumn) + patchesListBoxes[i]->getSelectedRow();
+    }
+
     delete patchesListModels[i];
     delete patchesListBoxes[i];
   }
 }
 
-void PatchBrowser::resized() {
+void PatchBrowser::resized()
+{
   categoriesListBox.setBounds(0, 0, 180, getHeight());
-  for (int i = 0; i < columns; i++) {
-    patchesListBoxes[i]->setBounds(180 + (getWidth() - 180) / columns * i, 0,
-                                   (getWidth() - 180) / columns, getHeight());
+
+  for (int i = 0; i < columns; i++)
+  {
+    patchesListBoxes[i]->setBounds(180 + (getWidth() - 180) / columns * i,
+                                   0,
+                                   (getWidth() - 180) / columns,
+                                   getHeight());
   }
 }


### PR DESCRIPTION
Partially addresses #39.

If the same thing is done with patches, this eradicates any user edits on GUI reopen, since selecting a row in JUCE automatically executes the selectedRowsChanged() callback, which in this case calls setCurrentProgram(), which clobbers everything.