### PR TITLE
Fixed memory leak and some smaller stuff

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -176,9 +176,8 @@ VirtualJVProcessor::VirtualJVProcessor()
           patchesOffset = 0x18602;
       }
 
-      char *namePtr = (char *)calloc(32, 1);
-      patchInfos[currentPatchI].name = namePtr;
-      sprintf(namePtr, "Rhythm Set %d", j + 1);
+      ownedNames.push_back("Rhythm Set " + std::to_string(j + 1));
+      patchInfos[currentPatchI].name = ownedNames.back().c_str();
 
       patchInfos[currentPatchI].ptr =
           (const char *)&expansionsDescr[i][patchesOffset + j * 0xa7c];
@@ -188,7 +187,7 @@ VirtualJVProcessor::VirtualJVProcessor()
             (const char *)&loadedRoms[getRomIndex("rd500_patches.bin")]
                                      [patchesOffset];
 
-      patchInfos[currentPatchI].nameLength = strlen(namePtr);
+      patchInfos[currentPatchI].nameLength = (int)ownedNames.back().size();
       patchInfos[currentPatchI].expansionI = i;
       patchInfos[currentPatchI].patchI = j;
       patchInfos[currentPatchI].present = true;
@@ -208,7 +207,6 @@ VirtualJVProcessor::VirtualJVProcessor()
 
 VirtualJVProcessor::~VirtualJVProcessor() {
   mcuLock.enter();
-  memset(mcu, 0, sizeof(MCU));
   delete mcu;
   mcuLock.exit();
 }
@@ -288,6 +286,8 @@ void VirtualJVProcessor::setCurrentProgram(int index) {
 }
 
 const juce::String VirtualJVProcessor::getProgramName(int index) {
+  if (index < 0 || index >= getNumPrograms())
+    return {};
   int length = patchInfos[index].nameLength;
   const char *strPtr = (const char *)patchInfos[index].name;
   return juce::String(strPtr, length);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -103,6 +103,7 @@ public:
     int totalPatchesExp = 0;
 
     std::array<uint8_t*, romCount> loadedRoms = {0};
+    std::vector<std::string> ownedNames;
     bool loaded = false;
 
     juce::SpinLock mcuLock;

--- a/Source/emulator/mcu.cpp
+++ b/Source/emulator/mcu.cpp
@@ -1173,7 +1173,6 @@ int MCU::startSC55(const uint8_t* s_rom1, const uint8_t* s_rom2, const uint8_t* 
             break;
         case ROM_SET_JV880:
             mcu_jv880 = true;
-            rom2_mask /= 2; // rom is half the size
             lcd.lcd_width = 820;
             lcd.lcd_height = 100;
             break;
@@ -1187,7 +1186,7 @@ int MCU::startSC55(const uint8_t* s_rom1, const uint8_t* s_rom2, const uint8_t* 
 
     memcpy(rom1, s_rom1, ROM1_SIZE);
     memcpy(rom2, s_rom2, ROM2_SIZE_JV880);
-    rom2_mask = ROM2_SIZE_JV880 - 1;
+    rom2_mask = ROM2_SIZE_JV880 - 1; // jv880 rom2 is half the size of other rom sets
     memcpy(nvram, s_nvram, NVRAM_SIZE);
 
     if (mcu_mk1)

--- a/Source/ui/EditToneTab.cpp
+++ b/Source/ui/EditToneTab.cpp
@@ -124,7 +124,7 @@ EditToneTab::EditToneTab
     aftDestALabel.attachToComponent(&aftDestAComboBox, true);
 
     addAndMakeVisible(aftDestAComboBox);
-    aftDestAComboBox.addListener(this);;
+    aftDestAComboBox.addListener(this);
     addMenuEntriesFromArray(aftDestAComboBox, modSources);
 
     addAndMakeVisible(aftSensASlider);

--- a/VirtualJV.jucer
+++ b/VirtualJV.jucer
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <JUCERPROJECT id="DSwmeO" name="virtual_jv" projectType="audioplug" useAppConfig="0"
-              addUsingNamespaceToJuceHeader="0" jucerFormatVersion="1" pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
+              version="1.0.1" addUsingNamespaceToJuceHeader="0" jucerFormatVersion="1" pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
               pluginManufacturerCode="GlZs" pluginCode="VRJV" cppLanguageStandard="17"
               pluginFormats="buildAU,buildLV2,buildStandalone,buildVST3" pluginName="VirtualJV"
               pluginDesc="VirtualJV" companyName="Giulio Zausa" lv2Uri="https://www.GiulioZausa.com/plugins/virtual_jv">
@@ -86,6 +86,8 @@
     <MODULE id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="0"
             useGlobalPath="0"/>
     <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
+    <MODULE id="juce_audio_processors_headless" showAllCode="1" useLocalCopy="0"
+            useGlobalPath="0"/>
     <MODULE id="juce_audio_utils" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
@@ -115,6 +117,7 @@
         <MODULEPATH id="juce_audio_devices" path="./JUCE/modules"/>
         <MODULEPATH id="juce_audio_utils" path="./JUCE/modules"/>
         <MODULEPATH id="juce_animation" path="./JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
     <XCODE_IPHONE targetFolder="Builds/iOS" bigIcon="DiWlj3" smallIcon="DiWlj3">
@@ -136,6 +139,7 @@
         <MODULEPATH id="juce_graphics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_basics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_extra" path="./JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile" smallIcon="DiWlj3" bigIcon="DiWlj3">
@@ -157,6 +161,7 @@
         <MODULEPATH id="juce_graphics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_basics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_extra" path="./JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </LINUX_MAKE>
     <VS2022 targetFolder="Builds/VisualStudio2022" smallIcon="DiWlj3" bigIcon="DiWlj3">
@@ -179,6 +184,7 @@
         <MODULEPATH id="juce_audio_utils" path="./JUCE/modules"/>
         <MODULEPATH id="juce_audio_formats" path="./JUCE/modules"/>
         <MODULEPATH id="juce_audio_devices" path="./JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </VS2022>
   </EXPORTFORMATS>


### PR DESCRIPTION
Drum kit names were allocated with calloc and stored as raw const char* pointers in patchInfos, but never freed up, creating a tiny memory leak on every plugin instantiation. Names are now constructed with std::string and pushed into the vector that owns the string data for the lifetime of the processor instance and cleans up automatically when the plugin is destroyed. 