### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: 
       - '**'
+  workflow_dispatch:
 
 jobs:
   build-win:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
               ./Builds/VisualStudio2022/x64/Release/VST3/jv880.vst3
               ./Builds/VisualStudio2022/x64/Release/Standalone Plugin/jv880.exe
   build-osx:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v3.3.0
       with:

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -16,6 +16,8 @@ VirtualJVProcessor::VirtualJVProcessor()
               .withInput("Input", juce::AudioChannelSet::stereo(), true)
               .withOutput("Output", juce::AudioChannelSet::stereo(), true)) {
 
+  ownedNames.reserve(52);
+
   mcu = new MCU();
 
   if (!preloadAll(loadedRoms))

--- a/Source/ui/widgets/Slider.h
+++ b/Source/ui/widgets/Slider.h
@@ -76,6 +76,11 @@ public:
         setLookAndFeel(&lookAndFeel);
     };
 
+    ~Slider()
+    {
+        setLookAndFeel(nullptr);
+    }
+
     void mouseDown(const juce::MouseEvent& e) override
     {
         if (isEnabled() && e.mods.isRightButtonDown())

--- a/VirtualJV.jucer
+++ b/VirtualJV.jucer
@@ -86,8 +86,6 @@
     <MODULE id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="0"
             useGlobalPath="0"/>
     <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
-    <MODULE id="juce_audio_processors_headless" showAllCode="1" useLocalCopy="0"
-            useGlobalPath="0"/>
     <MODULE id="juce_audio_utils" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
@@ -117,7 +115,6 @@
         <MODULEPATH id="juce_audio_devices" path="./JUCE/modules"/>
         <MODULEPATH id="juce_audio_utils" path="./JUCE/modules"/>
         <MODULEPATH id="juce_animation" path="./JUCE/modules"/>
-        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
     <XCODE_IPHONE targetFolder="Builds/iOS" bigIcon="DiWlj3" smallIcon="DiWlj3">
@@ -139,7 +136,6 @@
         <MODULEPATH id="juce_graphics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_basics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_extra" path="./JUCE/modules"/>
-        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile" smallIcon="DiWlj3" bigIcon="DiWlj3">
@@ -161,7 +157,6 @@
         <MODULEPATH id="juce_graphics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_basics" path="./JUCE/modules"/>
         <MODULEPATH id="juce_gui_extra" path="./JUCE/modules"/>
-        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </LINUX_MAKE>
     <VS2022 targetFolder="Builds/VisualStudio2022" smallIcon="DiWlj3" bigIcon="DiWlj3">
@@ -184,7 +179,6 @@
         <MODULEPATH id="juce_audio_utils" path="./JUCE/modules"/>
         <MODULEPATH id="juce_audio_formats" path="./JUCE/modules"/>
         <MODULEPATH id="juce_audio_devices" path="./JUCE/modules"/>
-        <MODULEPATH id="juce_audio_processors_headless" path="./JUCE/modules"/>
       </MODULEPATHS>
     </VS2022>
   </EXPORTFORMATS>


### PR DESCRIPTION
- Fix problem with the "ownedNames" array introduced to fix a memory leak: a std::vector should be pre-allocated with reserve(), otherwise every time a new element is added, the whole vector gets destroyed and re-allocated to a bigger size. So any previous calls to ownedNames.back().c_str() now point to deleted memory.
- Fix asserts triggered when shutting down the VST (debug only). When setting a custom LookAndFeel, setLookAndFeel(nullptr) needs to be called in the destructor.

Github workflow fixes:
- builds weren't working anymore because "juce_audio_processors_headless" is a recent and not widespread Juce module. Moreover it's not even used by the VST itself so it doesn't need to be in the Projucer file.
- build-osx was stuck in an endless loop waiting for an agent, because "macos-13" has been retired by github in December 2025

Note: some of those problems were introduced by pull request [116](https://github.com/giulioz/jv880_juce/pull/116)

Awesome work by the way, this VST plugin is incredible!