### PR TITLE
Fix one sample dropped per block on odd render lengths

### DIFF
--- a/Source/emulator/mcu.cpp
+++ b/Source/emulator/mcu.cpp
@@ -1253,7 +1253,21 @@ void MCU::updateSC55WithSampleRate(float *dataL, float *dataR, unsigned int nFra
         return;
     }
 
-    sample_write_ptr = 0;
+    // Deliberately NOT reset to 0 unconditionally. The PCM chip posts samples in
+    // pairs (oversampling is unconditionally on in PCM_Update), so the loop
+    // below, which stops at `sample_write_ptr >= renderBufferFrames`, overshoots
+    // by exactly one sample whenever renderBufferFrames is odd. Resetting the
+    // write pointer here threw that sample away, punching a one-sample gap into
+    // the 64 kHz stream on every block. Those samples are already sitting at the
+    // front of sample_buffer_*, carried over by the memmove at the bottom of
+    // this function, and sample_write_ptr is their count, so the loop simply
+    // renders fewer of its own.
+    //
+    // A rate change is the one case where the carry is dropped: the resampler is
+    // reopened below, so its history and phase restart and the output is
+    // discontinuous there regardless.
+    if (savedDestSampleRate != destSampleRate)
+        sample_write_ptr = 0;
 
     int maxCycles = nFrames * 256;
 
@@ -1312,6 +1326,24 @@ void MCU::updateSC55WithSampleRate(float *dataL, float *dataR, unsigned int nFra
 
     outL = resample_process(resampleL, ratio, sample_buffer_l, renderBufferFrames, false, &inUsedL, dataL, nFrames);
     outR = resample_process(resampleR, ratio, sample_buffer_r, renderBufferFrames, false, &inUsedR, dataR, nFrames);
+
+    // The resampler was handed the first renderBufferFrames samples. Anything
+    // past that is the odd-length overshoot described at the top of this
+    // function: move it to the front of the buffer and let the next block
+    // continue from there, so the 64 kHz stream stays gap-free across block
+    // boundaries. Bounded at one sample, because PCM_Update only ever advances
+    // sample_write_ptr by an even count and so cannot step over
+    // renderBufferFrames by more than one.
+    const unsigned int leftover = (unsigned int)sample_write_ptr > renderBufferFrames
+                                    ? (unsigned int)sample_write_ptr - renderBufferFrames
+                                    : 0u;
+    if (leftover > 0) {
+        memmove(sample_buffer_l, sample_buffer_l + renderBufferFrames,
+                leftover * sizeof(sample_buffer_l[0]));
+        memmove(sample_buffer_r, sample_buffer_r + renderBufferFrames,
+                leftover * sizeof(sample_buffer_r[0]));
+    }
+    sample_write_ptr = (int)leftover;
 
     samplesError += currentError;
     // printf("error: %f total: %f\n", currentError, samplesError);

--- a/tools/blockdrop/.gitignore
+++ b/tools/blockdrop/.gitignore
@@ -1,0 +1,1 @@
+blockdrop_test

--- a/tools/blockdrop/blockdrop_test.cpp
+++ b/tools/blockdrop/blockdrop_test.cpp
@@ -1,0 +1,376 @@
+/*
+ * blockdrop_test.cpp — does updateSC55WithSampleRate() drop a sample per block?
+ *
+ * Standalone: links the emulator core only, no JUCE. Renders the same chord on
+ * the power-on default patch at several (host rate, block size) pairs and
+ * reports the 4-8 kHz band RMS of the result.
+ *
+ * The reasoning the measurement rests on:
+ *
+ *   renderBufferFrames = ceil(nFrames * 64000 / hostRate). PCM_Update posts
+ *   samples in PAIRS, so a loop stopping at `sample_write_ptr >=
+ *   renderBufferFrames` overshoots by one exactly when that count is ODD.
+ *
+ *   At hostRate == 64000 the resampler is a 1:1 pass, so a 32- vs 33-frame
+ *   block at 64000 differs in NOTHING except the parity of renderBufferFrames.
+ *   That pair is the controlled experiment; everything else is corroboration.
+ *
+ * Usage:  blockdrop_test <rom-dir>
+ *
+ * <rom-dir> holds the five core dumps under their upstream names:
+ *   jv880_rom1.bin jv880_rom2.bin jv880_waverom1.bin jv880_waverom2.bin
+ *   jv880_nvram.bin
+ * The waveroms are unscrambled here, exactly as rom.cpp does it, because
+ * startSC55() expects them descrambled.
+ */
+#include "../../Source/emulator/mcu.h"
+
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// ---------------------------------------------------------------- ROM loading
+
+static bool readFile(const std::string &path, std::vector<uint8_t> &out, size_t expect) {
+    FILE *f = fopen(path.c_str(), "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path.c_str()); return false; }
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (expect && (size_t)len != expect) {
+        fprintf(stderr, "%s: expected %zu bytes, got %ld\n", path.c_str(), expect, len);
+        fclose(f);
+        return false;
+    }
+    out.resize((size_t)len);
+    size_t got = fread(out.data(), 1, out.size(), f);
+    fclose(f);
+    if (got != out.size()) { fprintf(stderr, "short read on %s\n", path.c_str()); return false; }
+    return true;
+}
+
+// Verbatim from Source/rom.cpp so the harness cannot disagree with the plugin
+// about what the wave ROMs contain.
+static void unscrambleRomLocal(const uint8_t *src, uint8_t *dst, int len) {
+    for (int i = 0; i < len; i++) {
+        int address = i & ~0xfffff;
+        static const int aa[] = {2, 0,  3,  4,  1, 9, 13, 10, 18, 17,
+                                 6, 15, 11, 16, 8, 5, 12, 7,  14, 19};
+        for (int j = 0; j < 20; j++)
+            if (i & (1 << j)) address |= 1 << aa[j];
+        uint8_t srcdata = src[address];
+        uint8_t data = 0;
+        static const int dd[] = {2, 0, 4, 5, 7, 6, 3, 1};
+        for (int j = 0; j < 8; j++)
+            if (srcdata & (1 << dd[j])) data |= 1 << j;
+        dst[i] = data;
+    }
+}
+
+// ------------------------------------------------------------------- analysis
+
+// Iterative radix-2 FFT, in place. n must be a power of two.
+static void fft(std::vector<std::complex<double>> &a) {
+    const size_t n = a.size();
+    for (size_t i = 1, j = 0; i < n; i++) {
+        size_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) j ^= bit;
+        j ^= bit;
+        if (i < j) std::swap(a[i], a[j]);
+    }
+    for (size_t len = 2; len <= n; len <<= 1) {
+        const double ang = -2.0 * M_PI / (double)len;
+        const std::complex<double> wl(std::cos(ang), std::sin(ang));
+        for (size_t i = 0; i < n; i += len) {
+            std::complex<double> w(1.0, 0.0);
+            for (size_t k = 0; k < len / 2; k++) {
+                const std::complex<double> u = a[i + k];
+                const std::complex<double> v = a[i + k + len / 2] * w;
+                a[i + k] = u + v;
+                a[i + k + len / 2] = u - v;
+                w *= wl;
+            }
+        }
+    }
+}
+
+// RMS of x restricted to [loHz, hiHz), via Parseval on a zero-padded FFT.
+// Passing 0 / rate/2 gives the full-band RMS, which is how the level sanity
+// check below is computed — same code path, so the two cannot drift apart.
+static double bandRms(const std::vector<float> &x, double rate, double loHz, double hiHz) {
+    if (x.empty()) return 0.0;
+    size_t m = 1;
+    while (m < x.size()) m <<= 1;
+    std::vector<std::complex<double>> buf(m, {0.0, 0.0});
+    for (size_t i = 0; i < x.size(); i++) buf[i] = {(double)x[i], 0.0};
+    fft(buf);
+
+    const double binHz = rate / (double)m;
+    const size_t kLo = (size_t)std::ceil(loHz / binHz);
+    const size_t kHi = (size_t)std::min((double)(m / 2), std::floor(hiHz / binHz));
+
+    double sum = 0.0;
+    for (size_t k = kLo; k < kHi; k++) sum += std::norm(buf[k]);
+    sum *= 2.0; // the mirrored negative-frequency half
+
+    // Power averaged over the ORIGINAL sample count, not the padded length.
+    const double power = sum / ((double)x.size() * (double)m);
+    return std::sqrt(power);
+}
+
+static double db(double v) { return v > 0.0 ? 20.0 * std::log10(v) : -999.0; }
+
+// FNV-1a over the raw bytes of the render. Two runs agreeing here agree
+// sample-for-sample, which is how "the fix is a no-op on even lengths" gets
+// stated as a fact rather than as agreement to two decimal places.
+static uint64_t hashSamples(const std::vector<float> &x) {
+    uint64_t h = 1469598103934665603ULL;
+    const unsigned char *p = (const unsigned char *)x.data();
+    for (size_t i = 0; i < x.size() * sizeof(float); i++) {
+        h ^= p[i];
+        h *= 1099511628211ULL;
+    }
+    return h;
+}
+
+// ------------------------------------------------------------ patch selection
+
+// The 192 internal patches, at the ROM2 offsets PluginProcessor.cpp uses. Each
+// record is 0x16a bytes and opens with a 12-character name.
+struct PatchSlot { const char *bank; int base; };
+static const PatchSlot kBanks[] = {
+    {"User",       0x008ce0},
+    {"Internal A", 0x010ce0},
+    {"Internal B", 0x018ce0},
+};
+static const int kPatchesPerBank = 64;
+static const int kPatchRecord = 0x16a;
+
+static std::string patchName(const std::vector<uint8_t> &rom2, int bank, int j) {
+    const uint8_t *p = &rom2[kBanks[bank].base + j * kPatchRecord];
+    std::string n((const char *)p, 12);
+    while (!n.empty() && (n.back() == ' ' || n.back() == '\0')) n.pop_back();
+    return n;
+}
+
+// Mirrors the non-drum half of VirtualJVProcessor::setCurrentProgram: mark the
+// temp area as holding a patch, copy the record in, reset. Must run AFTER
+// startSC55, which reloads nvram from the dump and resets on its own.
+static void selectPatch(MCU &mcu, const std::vector<uint8_t> &rom2, int bank, int j) {
+    mcu.nvram[0x11] = 1;
+    memcpy(&mcu.nvram[0x0d70], &rom2[kBanks[bank].base + j * kPatchRecord], kPatchRecord);
+    mcu.SC55_Reset();
+}
+
+// ---------------------------------------------------------------------- render
+
+struct Result {
+    double bandDb;
+    double fullDb;
+    double peak;
+    unsigned int renderBufferFrames;
+    uint64_t hash;       // FNV-1a over the rendered samples, for bit-exactness
+    long long dropped;   // emulator samples that never reached the resampler
+    long long carried;   // emulator samples held over for the next block
+};
+
+// Recomputes renderBufferFrames exactly as updateSC55WithSampleRate does,
+// including the samplesError half-buffer compensation. Both inputs are public
+// MCU members, so the harness can predict the value without instrumenting the
+// emulator at all — which is what lets the identical binary-level measurement
+// run against the patched and unpatched trees.
+static unsigned int predictRenderBufferFrames(double samplesError, int nFrames, int rate) {
+    const double f = (double)nFrames / rate * 64000.0;
+    unsigned int rbf = (unsigned int)std::ceil(f);
+    const int limit = nFrames / 2;
+    if (samplesError > limit)       rbf -= limit;
+    else if (-samplesError > limit) rbf += limit;
+    return rbf;
+}
+
+static Result renderChord(MCU &mcu, const std::vector<uint8_t> &rom1,
+                          const std::vector<uint8_t> &rom2,
+                          const std::vector<uint8_t> &wave1,
+                          const std::vector<uint8_t> &wave2,
+                          const std::vector<uint8_t> &nvram,
+                          int rate, int block, double seconds,
+                          int bank, int patchIdx) {
+    // Full restart per configuration: startSC55 memsets the MCU, reloads every
+    // ROM and calls SC55_Reset, so no state can leak between configurations and
+    // bias the comparison.
+    mcu.startSC55(rom1.data(), rom2.data(), wave1.data(), wave2.data(), nvram.data());
+    if (bank >= 0) selectPatch(mcu, rom2, bank, patchIdx);
+
+    std::vector<float> l((size_t)block), r((size_t)block);
+
+    // The emulated firmware ignores MIDI for roughly a second after a reset.
+    // Two seconds of silent blocks clears that window with margin.
+    const int warmup = (int)(2.0 * rate / block);
+    for (int b = 0; b < warmup; b++)
+        mcu.updateSC55WithSampleRate(l.data(), r.data(), (unsigned)block, rate);
+
+    const int blocks = (int)(seconds * rate / block);
+    std::vector<float> rec;
+    rec.reserve((size_t)blocks * (size_t)block);
+
+    long long dropped = 0, carried = 0;
+
+    for (int b = 0; b < blocks; b++) {
+        if (b == 2) {
+            // A four-note chord: far more broadband content than one note, and
+            // the same notes our fork's harness uses.
+            const uint8_t notes[4] = {60, 64, 67, 71};
+            for (uint8_t n : notes) {
+                const uint8_t msg[3] = {0x90, n, 100};
+                mcu.postMidiSC55(msg, 3);
+            }
+        }
+        // Predict the target BEFORE the call, while samplesError still holds the
+        // value the call will read.
+        const long long rbf = (long long)predictRenderBufferFrames(mcu.samplesError, block, rate);
+        mcu.updateSC55WithSampleRate(l.data(), r.data(), (unsigned)block, rate);
+
+        // The render loop stops at the first sample_write_ptr >= rbf and the
+        // resampler is handed exactly rbf samples, so anything beyond rbf is
+        // overshoot. What sample_write_ptr holds on return tells us its fate,
+        // and the two trees leave different things there:
+        //
+        //   unpatched: the loop-exit count, >= rbf. The next call's
+        //              `sample_write_ptr = 0` discards the excess.
+        //              -> (swp - rbf) samples DROPPED.
+        //   patched:   the leftover, 0 or 1, already memmoved to the front of
+        //              the buffer for the next block to consume.
+        //              -> (swp) samples CARRIED, none dropped.
+        //
+        // One expression covers both, and the counter it feeds means the same
+        // thing in each: how many emulator samples never reached the resampler.
+        // Note >=, not >. Unpatched with an EVEN count the loop lands exactly on
+        // rbf; that is the unpatched path with nothing dropped, not a carry.
+        const long long swp = (long long)mcu.sample_write_ptr;
+        if (swp >= rbf) dropped += swp - rbf;
+        else            carried += swp;
+
+        rec.insert(rec.end(), l.begin(), l.end());
+    }
+
+    Result out{};
+    out.bandDb = db(bandRms(rec, rate, 4000.0, 8000.0));
+    out.fullDb = db(bandRms(rec, rate, 0.0, rate / 2.0));
+    out.peak = 0.0;
+    for (float v : rec) out.peak = std::max(out.peak, (double)std::fabs(v));
+    out.renderBufferFrames = (unsigned int)std::ceil((double)block / rate * 64000.0);
+    out.hash = hashSamples(rec);
+    out.dropped = dropped;
+    out.carried = carried;
+    return out;
+}
+
+// ------------------------------------------------------------------------ main
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: blockdrop_test <rom-dir>\n");
+        return 2;
+    }
+    const std::string dir = std::string(argv[1]) + "/";
+
+    std::vector<uint8_t> rom1, rom2, nvram, wave1s, wave2s;
+    if (!readFile(dir + "jv880_rom1.bin", rom1, 32 * 1024)) return 1;
+    if (!readFile(dir + "jv880_rom2.bin", rom2, 256 * 1024)) return 1;
+    if (!readFile(dir + "jv880_nvram.bin", nvram, 32 * 1024)) return 1;
+    if (!readFile(dir + "jv880_waverom1.bin", wave1s, 2 * 1024 * 1024)) return 1;
+    if (!readFile(dir + "jv880_waverom2.bin", wave2s, 2 * 1024 * 1024)) return 1;
+
+    std::vector<uint8_t> wave1(wave1s.size()), wave2(wave2s.size());
+    unscrambleRomLocal(wave1s.data(), wave1.data(), (int)wave1s.size());
+    unscrambleRomLocal(wave2s.data(), wave2.data(), (int)wave2s.size());
+
+    const double seconds = getenv("JV880_SECS") ? atof(getenv("JV880_SECS")) : 3.0;
+
+    std::unique_ptr<MCU> scanMcu(new MCU());
+
+    // --scan: rank every internal patch by how much 4-8 kHz content it makes on
+    // its own, rendered in a configuration that has no artifact (even length,
+    // resampler bypassed). A patch near the bottom of this list leaves the most
+    // headroom for the defect to show above, which is the whole point of
+    // choosing one rather than accepting the power-on default.
+    if (argc > 2 && std::string(argv[2]) == "--scan") {
+        struct Row { double band; double peak; int bank; int idx; std::string name; };
+        std::vector<Row> rows;
+        for (int b = 0; b < 3; b++)
+            for (int j = 0; j < kPatchesPerBank; j++) {
+                Result r = renderChord(*scanMcu, rom1, rom2, wave1, wave2, nvram,
+                                       64000, 32, 1.5, b, j);
+                rows.push_back({r.bandDb, r.peak, b, j, patchName(rom2, b, j)});
+            }
+        std::sort(rows.begin(), rows.end(),
+                  [](const Row &a, const Row &c) { return a.band < c.band; });
+        printf("%-12s %-4s %-14s %10s %9s\n", "bank", "idx", "name", "4-8kHz dB", "peak");
+        printf("--------------------------------------------------------------\n");
+        for (const Row &r : rows) {
+            // Skip anything too quiet to measure meaningfully -- a silent patch
+            // trivially has no 4-8 kHz content and would top this list.
+            if (r.peak < 0.02) continue;
+            printf("%-12s %-4d %-14s %10.2f %9.5f\n",
+                   kBanks[r.bank].bank, r.idx, r.name.c_str(), r.band, r.peak);
+        }
+        return 0;
+    }
+
+    // --patch <bank> <idx> selects one for the sweep; default -1 keeps the
+    // power-on patch.
+    int useBank = -1, useIdx = 0;
+    if (argc > 4 && std::string(argv[2]) == "--patch") {
+        useBank = atoi(argv[3]);
+        useIdx = atoi(argv[4]);
+        printf("patch: %s #%d  \"%s\"\n\n", kBanks[useBank].bank, useIdx,
+               patchName(rom2, useBank, useIdx).c_str());
+    } else {
+        printf("patch: power-on default\n\n");
+    }
+
+    struct Config { int rate; int block; const char *note; };
+    const Config configs[] = {
+        {64000, 32, "resampler bypassed, even"},
+        {64000, 33, "resampler bypassed, ODD"},
+        {48000, 32, "ODD"},
+        {44100, 32, "ODD"},
+        {48000, 48, "even (control)"},
+    };
+
+    std::unique_ptr<MCU> mcu(new MCU());
+
+    printf("%-7s %-6s %-6s %-5s %10s %9s %8s %18s  %s\n",
+           "rate", "block", "rbFrm", "par", "4-8kHz dB", "DROPPED", "carried", "render hash", "note");
+    printf("---------------------------------------------------------------------------------------------\n");
+
+    bool anySilent = false;
+    for (const Config &c : configs) {
+        Result res = renderChord(*mcu, rom1, rom2, wave1, wave2, nvram,
+                                 c.rate, c.block, seconds, useBank, useIdx);
+        const bool odd = (res.renderBufferFrames % 2) != 0;
+        printf("%-7d %-6d %-6u %-5s %10.2f %9lld %8lld %18llx  %s\n",
+               c.rate, c.block, res.renderBufferFrames, odd ? "odd" : "even",
+               res.bandDb, res.dropped, res.carried,
+               (unsigned long long)res.hash, c.note);
+        if (res.peak < 1e-4) anySilent = true;
+        fflush(stdout);
+    }
+
+    // A measurement over silence is deterministic, reproducible and completely
+    // meaningless. Refuse to report one as a result.
+    if (anySilent) {
+        printf("\nFAIL: at least one configuration rendered silence — the numbers above\n"
+               "      describe nothing. Check the ROM set and the MIDI path.\n");
+        return 1;
+    }
+    printf("\nAll configurations rendered audible signal (peak > 1e-4).\n");
+    return 0;
+}

--- a/tools/blockdrop/build.sh
+++ b/tools/blockdrop/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Build the standalone block-drop harness against whatever the working tree
+# currently contains. Output: tools/blockdrop/blockdrop_test
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT="${1:-$ROOT/tools/blockdrop/blockdrop_test}"
+
+CXXFLAGS="-O2 -std=c++17 -Wno-multichar"
+CFLAGS="-O2"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+for c in filterkit resample resamplesubs; do
+  cc $CFLAGS -c "$ROOT/Source/emulator/resample/$c.c" -o "$TMP/$c.o"
+done
+
+OBJS=("$TMP"/*.o)
+c++ $CXXFLAGS \
+  "$ROOT/tools/blockdrop/blockdrop_test.cpp" \
+  "$ROOT/Source/emulator/mcu.cpp" \
+  "$ROOT/Source/emulator/mcu_opcodes.cpp" \
+  "$ROOT/Source/emulator/mcu_interrupt.cpp" \
+  "$ROOT/Source/emulator/mcu_timer.cpp" \
+  "$ROOT/Source/emulator/pcm.cpp" \
+  "$ROOT/Source/emulator/lcd.cpp" \
+  "$ROOT/Source/emulator/submcu.cpp" \
+  "${OBJS[@]}" \
+  -o "$OUT"
+
+echo "built $OUT"


### PR DESCRIPTION
# Fix one sample dropped per block on odd render lengths

## The bug

`updateSC55WithSampleRate()` resets `sample_write_ptr = 0` at the top of every block. But the PCM chip posts samples in **pairs** — oversampling is unconditionally on in `PCM_Update` — so the render loop, which stops at `sample_write_ptr >= renderBufferFrames`, overshoots by exactly one sample whenever `renderBufferFrames` is odd. The reset at the top of the next block then throws that sample away.

The result is a one-sample gap punched into the 64 kHz emulator stream on every single block. Not a click you hear once — a periodic discontinuity at block rate, which is broadband noise.

`renderBufferFrames = ceil(nFrames * 64000 / hostRate)`, so whether it fires depends on the host's sample rate **and** its buffer size. At a 32-frame buffer, 48000 gives 43 and 44100 gives 47 — odd on every block — while 64000 gives 32 and is clean.

## Measurement

`upstream/main` @ 3efd63b vs. this branch, same binary harness against both trees. Four-note chord (60, 64, 67, 71) on Internal A #48 "Fretless", 3 s render, via `tools/blockdrop` in the second commit:

| rate | block | renderBufferFrames | samples dropped | 4–8 kHz band RMS |
|---|---|---|---|---|
| 64000 | 32 | 32 (even) | 0 → 0 | −94.03 → −94.03 dB |
| 64000 | 33 | 33 (**odd**) | **5818 → 0** | −72.43 → **−92.15 dB** |
| 48000 | 32 | 43 (**odd**) | **4500 → 0** | −73.90 → **−92.97 dB** |
| 44100 | 32 | 47 (**odd**) | **4134 → 0** | −74.86 → **−94.25 dB** |
| 48000 | 48 | 64 (even) | 0 → 0 | −94.53 → −94.53 dB |

**The 64000 pair is the controlled experiment.** At 64000 the resampler is a straight 1:1 pass, so a 32- vs 33-frame block differs in nothing but the parity of `renderBufferFrames` — no resampling involved on either side. A **21.6 dB** gap collapses to 1.9 dB. 48000 at a 32-frame buffer, the common real-world case, sheds **19.1 dB** of 4–8 kHz junk.

**The drop counts are exactly one per block.** 5818, 4500 and 4134 are the block counts of those three runs — so the mechanism is an equality, not an inference. Every even configuration drops zero, before and after.

**Even lengths are bit-identical.** FNV-1a hashes of the rendered samples match exactly across the two trees — `84c519ccd895f530` at 64000/32 and `12a51faec92eeb4a` at 48000/48 — so this provably cannot regress any host whose buffer length is already even. Repeat runs reproduce every hash.

The patch was chosen by `--scan`, not guessed: it ranks all 192 internal patches by their own 4–8 kHz content, and "Fretless" is the darkest that still renders a healthy level. This matters more than it looks — on the power-on default patch the same defect measures only 1.4–1.7 dB, because that patch's own high-frequency content masks it.

## The fix

After the resampler has consumed the first `renderBufferFrames` samples, `memmove` whatever is past that to the front of the buffer and start the next block from there. Bounded at one sample, because `PCM_Update` only ever advances the write pointer by an even count and so cannot step over `renderBufferFrames` by more than one.

The unconditional reset becomes conditional on a rate change — the one case where the carry *should* be dropped, since the resampler is reopened a few lines below, so its history and phase restart and the output is discontinuous there regardless. `startSC55()` and `SC55_Reset()` both already zero `sample_write_ptr`, so startup and reset clear the carry for free.

33 insertions, 1 deletion, all in `updateSC55WithSampleRate()`.

## Build

Built through the project's own path — `Projucer --resave` then `xcodebuild -configuration Release` — **BUILD SUCCEEDED**, producing `jv880.app`. No new warnings on `mcu.cpp`; the one it emits (`-Wreturn-type` at line 347) is pre-existing and untouched here.

One local detail that is **not** part of this PR: with JUCE 8.0.13 the resave failed until Projucer was allowed to add `juce_audio_processors_headless` back to the `.jucer`. Since dd12947 deliberately removed that module, I reverted the change rather than ship it — flagging it only in case it signals a JUCE-version constraint worth knowing about.

## The second commit

`tools/blockdrop` is the harness that produced the table. It links the emulator core only — no JUCE, no Projucer — so it builds with a shell script in a couple of seconds.

Worth noting how it counts drops, since it needs **no instrumentation of the emulator at all**: `renderBufferFrames` is recomputed from `mcu.samplesError`, a public member, and what `sample_write_ptr` holds on return distinguishes the two cases by itself — the loop-exit count (`>= renderBufferFrames`, excess about to be discarded) before the fix, the carried leftover (0 or 1) after it. So one unmodified measurement binary runs against both trees.

It also refuses to report a result if any configuration rendered silence, which is the failure mode that would otherwise make the whole table look fine and mean nothing.

```
./tools/blockdrop/build.sh
./tools/blockdrop/blockdrop_test <rom-dir>                # power-on patch
./tools/blockdrop/blockdrop_test <rom-dir> --scan         # rank all 192 patches
./tools/blockdrop/blockdrop_test <rom-dir> --patch 1 48   # Internal A #48
```

Entirely separable — **drop that commit if you'd rather not have test tooling in the tree**, the fix stands alone.

## Provenance

Found while working on an iOS/AUv3 port of this project (not public yet), where it presented as "64 kHz is clean, 48 kHz aliases badly."

Written with Claude's help, as mentioned on Discord — happy to adjust anything.
