### PR TITLE
Emulator CPU: ~32% faster, bit-exact

### DIFF
--- a/Source/emulator/mcu.cpp
+++ b/Source/emulator/mcu.cpp
@@ -1232,6 +1232,56 @@ int MCU::startSC55(const uint8_t* s_rom1, const uint8_t* s_rom2, const uint8_t* 
     return 0;
 }
 
+uint64_t MCU::MCU_NextEventCycles(void)
+{
+    const uint64_t STEP = 12;
+    const uint64_t now = mcu.cycles; // always a multiple of STEP
+
+    // First multiple of STEP strictly greater than x / greater-or-equal to x.
+    auto nextStepAfter = [STEP](uint64_t x) { return (x / STEP + 1) * STEP; };
+    auto stepAtLeast = [STEP](uint64_t x) { return ((x + STEP - 1) / STEP) * STEP; };
+
+    uint64_t best = mcu_timer.TIMER_NextEventCycles(now);
+    auto bound = [&best](uint64_t when) { if (when < best) best = when; };
+
+    // UART RX fires when RX is enabled, a byte is queued, RDRF is clear and
+    // mcu.cycles has reached uart_rx_delay. The queue only grows via
+    // MCU_PostUART, which runs at the top of the emulation loop (from the MIDI
+    // queue) and only when sample_write_ptr moves — which needs a PCM step,
+    // which the bound below never skips. The SCR/SSR gates are firmware-owned
+    // and the firmware is asleep, so all of this is invariant across the jump.
+    if ((dev_register[DEV_SCR] & 16) && (uart_write_ptr != uart_read_ptr)
+        && !(dev_register[DEV_SSR] & 0x40))
+        bound(uart_rx_delay <= now ? now + STEP : stepAtLeast(uart_rx_delay));
+
+    // UART TX likewise: enabled, TDRE clear, and past uart_tx_delay.
+    if ((dev_register[DEV_SCR] & 32) && !(dev_register[DEV_SSR] & 0x80))
+        bound(uart_tx_delay <= now ? now + STEP : stepAtLeast(uart_tx_delay));
+
+    // A/D. With ADST set and no conversion scheduled, the next call schedules
+    // one at cycles+200 — a cycle-value-dependent write, so it must not be
+    // skipped. With one scheduled, the sample lands on the first call whose
+    // cycles exceeds analog_end_time. With ADST clear but a stale end time, the
+    // next call clears it, which is also a state change.
+    {
+        const int ctrl = dev_register[DEV_ADCSR];
+        if (ctrl & 0x20)
+            bound(analog_end_time == 0 ? now + STEP : nextStepAfter(analog_end_time));
+        else if (analog_end_time != 0)
+            bound(now + STEP);
+    }
+
+    // PCM. PCM_Update advances while pcm.cycles < the cycles handed to it, so
+    // its next body runs at the first step strictly past pcm.cycles. Binding
+    // here does double duty: it keeps sample pacing identical (no PCM step is
+    // ever skipped, so the loop cannot jump over the sample that satisfies the
+    // block), and it keeps sample_write_ptr — and therefore MIDI-queue
+    // eligibility — frozen across every skipped step.
+    bound(nextStepAfter(pcm.pcm.cycles));
+
+    return best;
+}
+
 void MCU::updateSC55WithSampleRate(float *dataL, float *dataR, unsigned int nFrames, int destSampleRate) {
     double renderBufferFramesFloat = (double)nFrames / destSampleRate * 64000;
     auto renderBufferFrames = (unsigned int)std::ceil(renderBufferFramesFloat);
@@ -1296,6 +1346,40 @@ void MCU::updateSC55WithSampleRate(float *dataL, float *dataR, unsigned int nFra
         }
         else
             mcu.ex_ignore = 0;
+
+        // Fast-forward through SLEEP. No instruction executes while the CPU is
+        // asleep, so the only state that can change comes from the peripherals;
+        // jump straight to the soonest step at which one of them could act
+        // instead of running the whole per-step machinery every 12 cycles.
+        //
+        // Gating on mcu.sleep alone is both correct and necessary. During SLEEP
+        // the firmware is waiting on an interrupt that is pending-but-masked, so
+        // interrupt_pending_any stays raised the entire time; gating on it too
+        // would disable this completely. Reaching here with mcu.sleep still set
+        // proves the MCU_Interrupt_Handle call above did not dispatch (a
+        // dispatch clears sleep), i.e. nothing is currently servable -- and that
+        // verdict can only change through a fresh request from a peripheral, or
+        // through a change to the SR interrupt mask. The mask only moves in
+        // firmware (asleep) or in StartVector (not reached), and the peripherals
+        // that can raise a request are exactly the ones MCU_NextEventCycles
+        // enumerates. External input (MIDI via the queue at the top of the loop,
+        // buttons and the encoder from outside this call) is accounted for
+        // there too, via the UART and PCM bounds.
+        //
+        // The `mcu_mk1 || mcu_jv880` test mirrors the UART/sub-MCU branch below:
+        // the sub-MCU's schedule is not modelled here, so machines that use it
+        // never fast-forward.
+        if (mcu.sleep && (mcu_mk1 || mcu_jv880))
+        {
+            const uint64_t target = MCU_NextEventCycles();
+            if (target != UINT64_MAX && target > mcu.cycles + 12)
+            {
+                // Replay the free-running counters for the TIMER_Clock calls
+                // being skipped; by construction none of them is observable.
+                mcu_timer.TIMER_AdvanceSkipped((target - 12 - mcu.cycles) / 12);
+                mcu.cycles = target - 12; // the += 12 below lands exactly on target
+            }
+        }
 
         if (!mcu.sleep)
             MCU_ReadInstruction();

--- a/Source/emulator/mcu.cpp
+++ b/Source/emulator/mcu.cpp
@@ -990,6 +990,7 @@ void MCU::MCU_Reset(void)
     mcu.pc = reset_address & 0xffff;
 
     mcu.exception_pending = -1;
+    mcu.interrupt_pending_any = 1; // force the first scan after a reset
 
     MCU_DeviceReset();
 
@@ -1286,7 +1287,13 @@ void MCU::updateSC55WithSampleRate(float *dataL, float *dataR, unsigned int nFra
        }
 
         if (!mcu.ex_ignore)
-            MCU_Interrupt_Handle(this);
+        {
+            // Same gate MCU_Interrupt_Handle applies internally, hoisted here so
+            // the common "nothing pending" case does not even pay for the
+            // cross-translation-unit call.
+            if (mcu.interrupt_pending_any)
+                MCU_Interrupt_Handle(this);
+        }
         else
             mcu.ex_ignore = 0;
 

--- a/Source/emulator/mcu.h
+++ b/Source/emulator/mcu.h
@@ -193,6 +193,13 @@ struct mcu_t {
     uint8_t interrupt_pending[INTERRUPT_SOURCE_MAX];
     uint8_t trapa_pending[16];
     uint64_t cycles;
+    // 1 = MCU_Interrupt_Handle must run its full scan; 0 = provably nothing is
+    // pending anywhere (no trapa, no exception, no interrupt request), so the
+    // scan can be skipped entirely. Set by every path that can make something
+    // pending; cleared only by a full scan that observed zero pending sources,
+    // so a pending-but-masked request keeps it set and still fires once the
+    // firmware lowers IMASK. See MCU_Interrupt_Handle.
+    uint8_t interrupt_pending_any;
 };
 
 enum {

--- a/Source/emulator/mcu.h
+++ b/Source/emulator/mcu.h
@@ -425,6 +425,11 @@ struct MCU {
     uint8_t MCU_DeviceRead(uint32_t address);
     void MCU_DeviceReset(void);
     void MCU_UpdateAnalog(uint64_t cycles);
+
+    // Earliest mcu.cycles value (a multiple of 12, strictly greater than the
+    // current one) at which any peripheral could do something observable. Used
+    // to fast-forward through SLEEP; UINT64_MAX if nothing is scheduled.
+    uint64_t MCU_NextEventCycles(void);
     void MCU_ReadInstruction(void);
     void MCU_Init(void);
     void MCU_Reset(void);

--- a/Source/emulator/mcu_interrupt.cpp
+++ b/Source/emulator/mcu_interrupt.cpp
@@ -52,6 +52,8 @@ void MCU_Interrupt_Start(MCU* mcu, int32_t mask)
 void MCU_Interrupt_SetRequest(MCU* mcu, uint32_t interrupt, uint32_t value)
 {
     mcu->mcu.interrupt_pending[interrupt] = value;
+    if (value)
+        mcu->mcu.interrupt_pending_any = 1;
 }
 
 void MCU_Interrupt_Exception(MCU* mcu, uint32_t exception)
@@ -63,11 +65,13 @@ void MCU_Interrupt_Exception(MCU* mcu, uint32_t exception)
         return;
 #endif
     mcu->mcu.exception_pending = exception;
+    mcu->mcu.interrupt_pending_any = 1;
 }
 
 void MCU_Interrupt_TRAPA(MCU* mcu, uint32_t vector)
 {
     mcu->mcu.trapa_pending[vector] = 1;
+    mcu->mcu.interrupt_pending_any = 1;
 }
 
 void MCU_Interrupt_StartVector(MCU* mcu, uint32_t vector, int32_t mask)
@@ -97,6 +101,23 @@ void MCU_Interrupt_Handle(MCU* mcu)
         return;
     }
 #endif
+    // Fast path: this scan touches ~29 sources and runs before every emulated
+    // instruction, but almost always finds nothing. The flag is raised by every
+    // path that can make something pending (SetRequest with a non-zero value,
+    // Exception, TRAPA) and lowered only at the bottom of this function, after a
+    // complete scan has observed that nothing at all is pending. A request that
+    // is pending but masked therefore leaves the flag raised and keeps getting
+    // re-scanned, so it still fires the moment the firmware lowers IMASK.
+    // Behaviour once anything is pending is byte-for-byte the original.
+    if (!mcu->mcu.interrupt_pending_any)
+        return;
+
+    // Tracks whether anything is still pending at the end of a scan that
+    // dispatched nothing. Only the masked-interrupt loop below needs to set it:
+    // the trapa / exception / NMI blocks all return, so reaching the bottom of
+    // the function already proves those three were clear.
+    bool any_pending = false;
+
     uint32_t i;
     for (i = 0; i < 16; i++)
     {
@@ -104,7 +125,7 @@ void MCU_Interrupt_Handle(MCU* mcu)
         {
             mcu->mcu.trapa_pending[i] = 0;
             MCU_Interrupt_StartVector(mcu, VECTOR_TRAPA_0 + i, -1);
-            return;
+            return; // flag stays raised: later trapas/interrupts may remain
         }
     }
     if (mcu->mcu.exception_pending >= 0)
@@ -138,6 +159,10 @@ void MCU_Interrupt_Handle(MCU* mcu)
         int32_t level = 0;
         if (!mcu->mcu.interrupt_pending[i])
             continue;
+        // Something is pending. Even if it turns out to be masked (or gated off
+        // by P1CR below), the flag must stay raised so the next mask change is
+        // noticed -- no fresh SetRequest will arrive to re-raise it.
+        any_pending = true;
         switch (i)
         {
             case INTERRUPT_SOURCE_IRQ0:
@@ -220,7 +245,14 @@ void MCU_Interrupt_Handle(MCU* mcu)
         {
             // mcu->mcu.interrupt_pending[INTERRUPT_SOURCE_NMI] = 0;
             MCU_Interrupt_StartVector(mcu, vector, level);
-            return;
+            return; // flag stays raised: lower-priority requests may remain
         }
     }
+
+    // A complete scan dispatched nothing. Lower the flag only if nothing at all
+    // is pending -- no trapa, no exception, no NMI (all three returned above if
+    // set) and no masked request (any_pending). Anything still pending keeps the
+    // flag up so the scan resumes when the mask drops.
+    if (!any_pending)
+        mcu->mcu.interrupt_pending_any = 0;
 }

--- a/Source/emulator/mcu_timer.cpp
+++ b/Source/emulator/mcu_timer.cpp
@@ -174,6 +174,99 @@ uint8_t MCU_Timer::TIMER_Read2(uint32_t address)
     return 0xff;
 }
 
+uint64_t MCU_Timer::TIMER_NextEventCycles(uint64_t now) const
+{
+    const uint64_t STEP = 12;
+    uint64_t best = UINT64_MAX;
+
+    // timer8 sets timer8_cmfa (and optionally requests CMIA) whenever
+    // (cycles & 0x3f) == 0. In this loop cycles is always a multiple of 12, so
+    // that condition holds exactly on the multiples of lcm(12, 64) = 192.
+    if (timer8_enabled)
+    {
+        uint64_t next192 = (now / 192 + 1) * 192;
+        if (next192 < best)
+            best = next192;
+    }
+
+    // Each FRT advances frc by +6 per CALL — the cadence is call-count driven,
+    // not cycle-value driven — and matches when (frc >> 2) >= ocra at the start
+    // of a call, i.e. when frc >= ocra * 4. So the match falls on call j, the
+    // smallest j >= 1 with frc + 6 * (j - 1) >= ocra * 4, which is the step at
+    // cycle now + 12 * j.
+    //
+    // A match is only observable from outside the timer when it raises an
+    // interrupt (ociea set) or when it flips ocfa from clear to set. When ociea
+    // is clear and ocfa is already set the match changes nothing anyone can see:
+    // it merely resets frc, which TIMER_AdvanceSkipped reproduces exactly. That
+    // is the common case here — this firmware leaves timer2 with ocra == 0 and
+    // ociea clear, so it "matches" on every single call while being invisible.
+    //
+    // frc is 16-bit, so an ocra whose target exceeds 0xffff can never be reached.
+    // Where the +6 stride overshoots past 0xffff the real counter wraps and does
+    // NOT match, which only ever makes the true event later than predicted —
+    // predicting early is safe here, it just ends the skip sooner.
+    auto frt_next = [&](uint16_t frc, uint16_t ocra, bool ociea,
+                        bool ocfa) -> uint64_t {
+        if (!ociea && ocfa)
+            return UINT64_MAX;
+        uint64_t target = (uint64_t)ocra << 2;
+        if (target > 0xffff)
+            return UINT64_MAX;
+        if ((uint64_t)frc >= target)
+            return now + STEP; // matches on the very next call
+        uint64_t jm1 = (target - frc + 5) / 6; // ceil((target - frc) / 6) >= 1
+        return now + STEP * (jm1 + 1);
+    };
+
+    uint64_t t;
+    t = frt_next(timer0_frc, timer0_ocra, timer0_ociea, timer0_ocfa);
+    if (t < best) best = t;
+    t = frt_next(timer1_frc, timer1_ocra, timer1_ociea, timer1_ocfa);
+    if (t < best) best = t;
+    t = frt_next(timer2_frc, timer2_ocra, timer2_ociea, timer2_ocfa);
+    if (t < best) best = t;
+
+    return best;
+}
+
+void MCU_Timer::TIMER_AdvanceSkipped(uint64_t n)
+{
+    // Mirrors TIMER_Clock's per-FRT arithmetic verbatim, minus the interrupt
+    // requests and minus timer8. Both omissions are licensed by the caller
+    // having stopped at or before TIMER_NextEventCycles(): any match replayed
+    // here has ociea clear and ocfa already set, so its request would not exist
+    // and its `ocfa |= 0x20` is a no-op; and no skipped step can be a multiple
+    // of 192, so timer8 cannot have fired. frc still has to be reproduced
+    // exactly, because a match resets it to 0.
+    for (uint64_t s = 0; s < n; s++)
+    {
+        if ((timer0_frc >> 2) >= timer0_ocra)
+        {
+            timer0_frc = 0;
+            timer0_ocfa |= 0x20;
+        }
+        else
+            timer0_frc += 6;
+
+        if ((timer1_frc >> 2) >= timer1_ocra)
+        {
+            timer1_frc = 0;
+            timer1_ocfa |= 0x20;
+        }
+        else
+            timer1_frc += 6;
+
+        if ((timer2_frc >> 2) >= timer2_ocra)
+        {
+            timer2_frc = 0;
+            timer2_ocfa |= 0x20;
+        }
+        else
+            timer2_frc += 6;
+    }
+}
+
 void MCU_Timer::TIMER_Clock(uint64_t cycles)
 {
     if (timer8_enabled && (cycles & 0x3f) == 0)

--- a/Source/emulator/mcu_timer.h
+++ b/Source/emulator/mcu_timer.h
@@ -70,6 +70,18 @@ struct MCU_Timer {
     uint8_t TIMER_Read(uint32_t address);
     void TIMER_Clock(uint64_t cycles);
 
+    // Support for the SLEEP fast-forward in MCU::updateSC55WithSampleRate.
+    //
+    // TIMER_NextEventCycles returns the earliest cycle count strictly greater
+    // than `now` (always a multiple of 12) at which TIMER_Clock could do
+    // something the rest of the machine can observe, or UINT64_MAX if it never
+    // can. TIMER_AdvanceSkipped then replays the free-running-counter arithmetic
+    // for the TIMER_Clock calls the jump skipped. The two must be read together:
+    // the caller may only skip up to the boundary the first reports, which is
+    // what makes it safe for the second to omit the interrupt requests.
+    uint64_t TIMER_NextEventCycles(uint64_t now) const;
+    void TIMER_AdvanceSkipped(uint64_t n);
+
     void TIMER2_Write(uint32_t address, uint8_t data);
     uint8_t TIMER_Read2(uint32_t address);
 };

--- a/tools/blockdrop/blockdrop_test.cpp
+++ b/tools/blockdrop/blockdrop_test.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <chrono>
 
 // ---------------------------------------------------------------- ROM loading
 
@@ -176,6 +177,8 @@ struct Result {
     double fullDb;
     double peak;
     unsigned int renderBufferFrames;
+    double renderSeconds;   // wall time of the render loop alone
+    uint64_t emulatedCycles; // mcu.cycles at the end -- the emulated timeline
     uint64_t hash;       // FNV-1a over the rendered samples, for bit-exactness
     long long dropped;   // emulator samples that never reached the resampler
     long long carried;   // emulator samples held over for the next block
@@ -222,12 +225,16 @@ static Result renderChord(MCU &mcu, const std::vector<uint8_t> &rom1,
 
     long long dropped = 0, carried = 0;
 
+    const auto t0 = std::chrono::steady_clock::now();
+
     for (int b = 0; b < blocks; b++) {
         if (b == 2) {
             // A four-note chord: far more broadband content than one note, and
             // the same notes our fork's harness uses.
             const uint8_t notes[4] = {60, 64, 67, 71};
-            for (uint8_t n : notes) {
+            const int nNotes = getenv("JV880_NOTES") ? atoi(getenv("JV880_NOTES")) : 4;
+            for (int ni = 0; ni < nNotes && ni < 4; ni++) {
+                const uint8_t n = notes[ni];
                 const uint8_t msg[3] = {0x90, n, 100};
                 mcu.postMidiSC55(msg, 3);
             }
@@ -260,7 +267,11 @@ static Result renderChord(MCU &mcu, const std::vector<uint8_t> &rom1,
         rec.insert(rec.end(), l.begin(), l.end());
     }
 
+    const auto t1 = std::chrono::steady_clock::now();
+
     Result out{};
+    out.renderSeconds = std::chrono::duration<double>(t1 - t0).count();
+    out.emulatedCycles = mcu.mcu.cycles;
     out.bandDb = db(bandRms(rec, rate, 4000.0, 8000.0));
     out.fullDb = db(bandRms(rec, rate, 0.0, rate / 2.0));
     out.peak = 0.0;
@@ -295,6 +306,7 @@ int main(int argc, char **argv) {
     const double seconds = getenv("JV880_SECS") ? atof(getenv("JV880_SECS")) : 3.0;
 
     std::unique_ptr<MCU> scanMcu(new MCU());
+    std::unique_ptr<MCU> mcu(new MCU());
 
     // --scan: rank every internal patch by how much 4-8 kHz content it makes on
     // its own, rendered in a configuration that has no artifact (even length,
@@ -324,6 +336,105 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    // --stress <rate> <block>: the bit-exactness workload the plain sweep does
+    // NOT cover. A sustained chord exercises almost no MIDI traffic and never
+    // releases a voice, which is exactly the wrong shape for validating changes
+    // to interrupt dispatch, timer scheduling and PCM voice state. This drives
+    // continuous note on/off churn across the whole keyboard plus periodic
+    // program changes, so the UART keeps delivering bytes, voices keep entering
+    // and leaving release, and the firmware keeps being interrupted.
+    if (argc > 4 && std::string(argv[2]) == "--stress") {
+        const int rate = atoi(argv[3]);
+        const int block = atoi(argv[4]);
+        mcu->startSC55(rom1.data(), rom2.data(), wave1.data(), wave2.data(), nvram.data());
+        selectPatch(*mcu, rom2, 1, 48);
+
+        std::vector<float> l((size_t)block), r((size_t)block);
+        const int warmup = (int)(2.0 * rate / block);
+        for (int b = 0; b < warmup; b++)
+            mcu->updateSC55WithSampleRate(l.data(), r.data(), (unsigned)block, rate);
+
+        const int blocks = (int)(seconds * rate / block);
+        std::vector<float> rec;
+        rec.reserve((size_t)blocks * (size_t)block);
+
+        // Deterministic pseudo-random churn: same sequence in both trees, so a
+        // hash mismatch means the emulator diverged, not the stimulus.
+        uint32_t rng = 0x12345678;
+        auto next = [&rng]() { rng = rng * 1664525u + 1013904223u; return rng >> 16; };
+        std::vector<uint8_t> held;
+
+        for (int b = 0; b < blocks; b++) {
+            const uint32_t roll = next() % 100;
+            if (roll < 30) {
+                const uint8_t note = (uint8_t)(36 + next() % 48);
+                const uint8_t on[3] = {0x90, note, (uint8_t)(40 + next() % 80)};
+                mcu->postMidiSC55(on, 3);
+                held.push_back(note);
+            } else if (roll < 55 && !held.empty()) {
+                const size_t k = next() % held.size();
+                const uint8_t off[3] = {0x80, held[k], 64};
+                mcu->postMidiSC55(off, 3);
+                held.erase(held.begin() + (long)k);
+            } else if (roll < 60) {
+                const uint8_t cc[3] = {0xB0, 1, (uint8_t)(next() % 128)}; // mod wheel
+                mcu->postMidiSC55(cc, 3);
+            } else if (roll == 61) {
+                const uint8_t pc[2] = {0xC0, (uint8_t)(next() % 64)};
+                mcu->postMidiSC55(pc, 2);
+            } else if (roll == 62) {
+                // Front-panel input. Named explicitly in the SLEEP
+                // fast-forward's correctness argument as state arriving from
+                // outside the render call, so it has to be in the workload that
+                // validates it -- MIDI alone would leave that claim untested.
+                mcu->MCU_EncoderTrigger((int)(next() & 1));
+            } else if (roll == 63) {
+                mcu->mcu_button_pressed = 1u << (next() % 8);
+            } else if (roll == 64) {
+                mcu->mcu_button_pressed = 0;
+            }
+            mcu->updateSC55WithSampleRate(l.data(), r.data(), (unsigned)block, rate);
+            rec.insert(rec.end(), l.begin(), l.end());
+        }
+
+        double peak = 0.0;
+        for (float v : rec) peak = std::max(peak, (double)std::fabs(v));
+        printf("stress %d/%d  %.1fs  events~%d  peak=%.5f  cycles=%llu  hash=%llx\n",
+               rate, block, seconds, blocks, peak,
+               (unsigned long long)mcu->mcu.cycles,
+               (unsigned long long)hashSamples(rec));
+        if (peak < 1e-4) { printf("FAIL: stress rendered silence\n"); return 1; }
+        return 0;
+    }
+
+    // --bench <rate> <block> [reps]: time the render loop alone, best of reps.
+    // Best-of rather than mean: scheduling noise only ever ADDS time, so the
+    // minimum is the least-contaminated estimate of the work actually done.
+    // Also reports mcu.cycles, the emulated timeline -- an optimisation that is
+    // genuinely just doing less work per step leaves this identical, while one
+    // that changed WHEN things happen would move it.
+    if (argc > 4 && std::string(argv[2]) == "--bench") {
+        const int rate = atoi(argv[3]);
+        const int block = atoi(argv[4]);
+        const int reps = argc > 5 ? atoi(argv[5]) : 5;
+        const int bank = argc > 7 ? atoi(argv[6]) : 1;
+        const int idx  = argc > 7 ? atoi(argv[7]) : 48;
+
+        double best = 1e30;
+        uint64_t cycles = 0, hash = 0;
+        for (int i = 0; i < reps; i++) {
+            Result r = renderChord(*scanMcu, rom1, rom2, wave1, wave2, nvram,
+                                   rate, block, seconds, bank, idx);
+            best = std::min(best, r.renderSeconds);
+            cycles = r.emulatedCycles;
+            hash = r.hash;
+        }
+        printf("bench %d/%d  %.1fs audio  best-of-%d: %.4f s   cycles=%llu   hash=%llx\n",
+               rate, block, seconds, reps, best,
+               (unsigned long long)cycles, (unsigned long long)hash);
+        return 0;
+    }
+
     // --patch <bank> <idx> selects one for the sweep; default -1 keeps the
     // power-on patch.
     int useBank = -1, useIdx = 0;
@@ -345,7 +456,6 @@ int main(int argc, char **argv) {
         {48000, 48, "even (control)"},
     };
 
-    std::unique_ptr<MCU> mcu(new MCU());
 
     printf("%-7s %-6s %-6s %-5s %10s %9s %8s %18s  %s\n",
            "rate", "block", "rbFrm", "par", "4-8kHz dB", "DROPPED", "carried", "render hash", "note");

--- a/tools/blockdrop/blockdrop_test.cpp
+++ b/tools/blockdrop/blockdrop_test.cpp
@@ -161,6 +161,48 @@ static std::string patchName(const std::vector<uint8_t> &rom2, int bank, int j) 
     return n;
 }
 
+// Loads a descrambled expansion card into the PCM expansion window, exactly as
+// setCurrentProgram does when the selected patch lives on a card. The Cache
+// copies written by the plugin are already descrambled, so they go in verbatim.
+static std::vector<uint8_t> g_card;
+static bool loadCard(MCU &mcu, const std::string &cachePath) {
+    if (!readFile(cachePath, g_card, 0)) return false;
+    if (g_card.size() < 0x800000) g_card.resize(0x800000, 0);
+    memcpy(mcu.pcm.waverom_exp, g_card.data(), 0x800000);
+    return true;
+}
+
+// Card patch / rhythm-set tables, at the offsets PluginProcessor.cpp reads.
+static int cardPatchCount(const std::vector<uint8_t> &c) {
+    return c[0x67] | c[0x66] << 8;
+}
+static size_t cardPatchOffset(const std::vector<uint8_t> &c) {
+    return (size_t)(c[0x8f] | c[0x8e] << 8 | c[0x8d] << 16 | (uint32_t)c[0x8c] << 24);
+}
+static int cardDrumCount(const std::vector<uint8_t> &c) {
+    return c[0x69] | c[0x68] << 8;
+}
+static size_t cardDrumOffset(const std::vector<uint8_t> &c) {
+    return (size_t)(c[0x93] | c[0x92] << 8 | c[0x91] << 16 | (uint32_t)c[0x90] << 24);
+}
+
+// A card patch: same nvram write as an internal one, but the record comes from
+// the card image rather than ROM2.
+static void selectCardPatch(MCU &mcu, int j) {
+    mcu.nvram[0x11] = 1;
+    memcpy(&mcu.nvram[0x0d70], &g_card[cardPatchOffset(g_card) + (size_t)j * 0x16a], 0x16a);
+    mcu.SC55_Reset();
+}
+
+// A rhythm set. Different area, different size, and nvram[0x11] = 0 -- this is
+// the drum path, which keys many slots at once and is therefore the workload
+// most unlike a sustained melodic patch.
+static void selectDrumKit(MCU &mcu, int j) {
+    mcu.nvram[0x11] = 0;
+    memcpy(&mcu.nvram[0x67f0], &g_card[cardDrumOffset(g_card) + (size_t)j * 0xa7c], 0xa7c);
+    mcu.SC55_Reset();
+}
+
 // Mirrors the non-drum half of VirtualJVProcessor::setCurrentProgram: mark the
 // temp area as holding a patch, copy the record in, reset. Must run AFTER
 // startSC55, which reloads nvram from the dump and resets on its own.
@@ -209,7 +251,10 @@ static Result renderChord(MCU &mcu, const std::vector<uint8_t> &rom1,
     // ROM and calls SC55_Reset, so no state can leak between configurations and
     // bias the comparison.
     mcu.startSC55(rom1.data(), rom2.data(), wave1.data(), wave2.data(), nvram.data());
-    if (bank >= 0) selectPatch(mcu, rom2, bank, patchIdx);
+    if (!g_card.empty()) memcpy(mcu.pcm.waverom_exp, g_card.data(), 0x800000);
+    if (bank >= 0)        selectPatch(mcu, rom2, bank, patchIdx);
+    else if (bank == -2)  selectCardPatch(mcu, patchIdx);
+    else if (bank == -3)  selectDrumKit(mcu, patchIdx);
 
     std::vector<float> l((size_t)block), r((size_t)block);
 
@@ -346,8 +391,20 @@ int main(int argc, char **argv) {
     if (argc > 4 && std::string(argv[2]) == "--stress") {
         const int rate = atoi(argv[3]);
         const int block = atoi(argv[4]);
+        // Optional trailing "<cache-file> patch|drum <idx>" runs the churn on a
+        // card patch or a rhythm set instead of the default internal patch.
+        int sBank = 1, sIdx = 48;
+        if (argc > 7) {
+            if (!loadCard(*mcu, argv[5])) return 1;
+            sBank = std::string(argv[6]) == "drum" ? -3 : -2;
+            sIdx = atoi(argv[7]);
+            printf("card: %s %s #%d\n", argv[5], argv[6], sIdx);
+        }
         mcu->startSC55(rom1.data(), rom2.data(), wave1.data(), wave2.data(), nvram.data());
-        selectPatch(*mcu, rom2, 1, 48);
+        if (!g_card.empty()) memcpy(mcu->pcm.waverom_exp, g_card.data(), 0x800000);
+        if (sBank >= 0)       selectPatch(*mcu, rom2, sBank, sIdx);
+        else if (sBank == -2) selectCardPatch(*mcu, sIdx);
+        else                  selectDrumKit(*mcu, sIdx);
 
         std::vector<float> l((size_t)block), r((size_t)block);
         const int warmup = (int)(2.0 * rate / block);
@@ -435,15 +492,30 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    // --card <cache-file> <patch|drum> <idx>: run the same 5-config sweep, but
+    // with an expansion card mapped into the PCM expansion window and either one
+    // of its patches or one of its rhythm sets selected. Rhythm sets matter most
+    // here: they key many PCM slots at once, which is the workload least like
+    // the sustained melodic patches the other modes render.
+    int useBank = -1, useIdx = 0;
+    if (argc > 5 && std::string(argv[2]) == "--card") {
+        if (!loadCard(*mcu, argv[3])) return 1;
+        const bool drum = std::string(argv[4]) == "drum";
+        useIdx = atoi(argv[5]);
+        useBank = drum ? -3 : -2;
+        printf("card: %s  %s #%d  (card has %d patches, %d rhythm sets)\n\n",
+               argv[3], drum ? "rhythm set" : "patch", useIdx,
+               cardPatchCount(g_card), cardDrumCount(g_card));
+    }
+
     // --patch <bank> <idx> selects one for the sweep; default -1 keeps the
     // power-on patch.
-    int useBank = -1, useIdx = 0;
     if (argc > 4 && std::string(argv[2]) == "--patch") {
         useBank = atoi(argv[3]);
         useIdx = atoi(argv[4]);
         printf("patch: %s #%d  \"%s\"\n\n", kBanks[useBank].bank, useIdx,
                patchName(rom2, useBank, useIdx).c_str());
-    } else {
+    } else if (useBank == -1) {
         printf("patch: power-on default\n\n");
     }
 


### PR DESCRIPTION
# Emulator CPU: ~32% faster, bit-exact

Two optimisations to the emulation loop. Neither changes what comes out — the rendered samples are identical, and so is the emulated cycle timeline.

## Measurement

10 s of audio at 48000/512, best-of-7 wall time for the render loop alone (no ROM loading, no analysis), Internal A #48 "Fretless", Apple Silicon:

| | four-note chord | one note held |
|---|---|---|
| `upstream/main` @ 0402ab0 | 0.9359 s | 0.9150 s |
| + interrupt gate | 0.7304 s (−22.0%) | 0.6736 s (−26.4%) |
| + SLEEP fast-forward | **0.6458 s (−31.0%)** | **0.6108 s (−33.2%)** |

Best-of rather than mean because scheduling noise only ever *adds* time, so the minimum is the least-contaminated estimate. Percentages are from stock. The ratios should travel; the absolute numbers won't.

Both are engaging heavily, not just theoretically applicable — instrumented over 30 s of busy playback: the SLEEP jump fires **119,986 times, skipping 1,459,166 emulated steps**, and **98.6%** of interrupt scans are skipped (46,799,787 of 47,462,824).

## The two changes

**1. Gate the interrupt scan behind a pending flag.** `MCU_Interrupt_Handle` scans 16 trapa slots, the exception source, NMI and ~29 interrupt sources before every emulated instruction and almost always finds nothing. `interrupt_pending_any` is raised by every path that can make something pending (`SetRequest` with a non-zero value, `Exception`, `TRAPA`, `MCU_Reset`) and lowered only by a full scan that observed zero. A request that is pending but *masked* leaves the flag raised, so it keeps being re-scanned and still fires the instant the firmware lowers IMASK. The flag is also tested at the call site so the common case doesn't pay for the cross-TU call.

**2. Fast-forward `mcu.cycles` through SLEEP.** No instruction executes while the CPU sleeps, so only peripherals can change state; jump to the soonest step at which one could act rather than running the whole per-step machinery every 12 cycles. `MCU_NextEventCycles` enumerates the bounds — FRT match when it would raise an interrupt or newly set OCFA, timer8 at multiples of lcm(12,64), UART rx/tx once their delay is reached, the A/D schedule, and the next PCM step — and `TIMER_AdvanceSkipped` replays the free-running counters exactly. The PCM bound does double duty: no PCM step is ever skipped, so sample pacing and MIDI-queue eligibility are untouched. Machines running the sub-MCU never fast-forward, since that schedule isn't modelled here.

## Bit-exactness

Stated as measurement, not as a claim.

**The test can detect a defect.** Two deliberate perturbations were injected and both were caught, so the passes below aren't vacuous:

| injected defect | detected as |
|---|---|
| UART RX bound deleted from `MCU_NextEventCycles` (the "enumeration missed a peripheral" bug class) | render hash changed |
| flag lowered ignoring `any_pending` (drops a pending-but-masked request) | **total silence**, tripped the silence guard |

Worth noting: the first perturbation left `mcu.cycles` **identical**. The cycle count alone would have missed it — the render hash is the sensitive detector.

**Sustained-tone sweep.** FNV-1a hash of the rendered samples identical to unmodified upstream at 44100/32, 48000/32, 48000/48, 64000/32 and 64000/33 — after *each* commit individually, and across **12 internal patches** spanning all three banks. Re-run against `main` after #127 merged, since that changed the baseline: the odd-length hashes moved exactly as the odd-block fix predicts, and the two trees still agree byte for byte.

**Expansion cards and rhythm sets.** Same sweep with a card mapped into the PCM expansion window: **5 cards** (Pop, Dance, Techno, Special FX, Bass & Drum), card patches and rhythm sets, 5 configs each — every one identical. Rhythm sets are the point of including this: they key many PCM slots at once and go through a different selection path, making them the workload least like everything else in the suite. A 60 s MIDI-churn run on a rhythm set also matches exactly (hash `828ac7109e25bb23`, cycles and peak identical).

**Under load.** A held chord is close to the worst workload for validating interrupt and timer changes: almost no MIDI arrives and no voice ever releases. So a second workload drives continuous note on/off churn across the keyboard, mod-wheel CCs, program changes, **and front-panel encoder and button input** — the last specifically because state arriving from outside the render call is named in the SLEEP fast-forward's own correctness argument, and MIDI alone would leave that untested. Deterministic PRNG, so both trees get identical stimulus.

| config | duration | events | result |
|---|---|---|---|
| 48000/512 | **180 s** | ~17,000 | identical hash, cycles, peak |
| 48000/32 | 60 s | ~90,000 | identical |
| 44100/32 | 60 s | ~82,000 | identical |
| 64000/33 | 60 s | ~116,000 | identical |
| 96000/1024 | 60 s | ~5,600 | identical |
| 88200/256 | 60 s | ~20,000 | identical |

All of the above re-run against `main` at 0402ab0, i.e. after #127.

Peaks land above 1.0 throughout — loud, busy renders, not something passing by being quiet. Repeat runs reproduce every hash exactly.

**The emulated timeline is unchanged.** `mcu.cycles` is identical between the two trees in every run above. These commits make the host do less work per emulated step; they do not change *when* anything happens inside the machine.

## Build and run

`Projucer --resave` then `xcodebuild -configuration Release` — **BUILD SUCCEEDED** for both the Standalone and AU targets. No new warnings; the one `-Wreturn-type` at `mcu.cpp:347` reproduces identically on unmodified `upstream/main`.

**Standalone runs.** Launched the built app against a real ROM set: stays up, ~6.6% CPU idle, ROMs loaded, real CoreAudio callback at the device's own rate and buffer size.

**Loaded and played as an AU in a DAW on macOS**, including **expansion cards, drum kits, and a session longer than the automated soak**. No dropouts, hangs or stuck notes, and it sounds right.

The two kinds of evidence here cover different ground, and it's worth not blurring them:

| | covers | establishes |
|---|---|---|
| automated harness | internal patches, 5 expansion cards, card patches, rhythm sets, 6 rate/block configs, ≤180 s | **bit-exact** output |
| playing it in a host | extended session, real MIDI hardware, real-time callback, plugin wrapper | nothing audibly wrong |

Listening can't confirm bit-exactness and isn't offered as doing so — the hashes do that far more strictly. What playing it covers is the part the harness structurally cannot reach: the wrapper and the real-time callback under a real host.

**One thing to flag that is not about this PR.** I also tried `auval -v aumu VRJV GlZs`, and it dies with exit 137 (SIGKILL) immediately after *"This AudioUnit is a version 2 implementation"*, before reaching the parameter, property or render tests. I then built the AU from unmodified `upstream/main` and ran the same command: **identical failure, same exit code, same 21 lines of output, logs diff clean apart from timings.**

So it is pre-existing on `main` in my environment (macOS 26, JUCE 8.0.13, ad-hoc-signed build), not something this change introduces — and since the plugin does load and play correctly in a host, it looks like an `auval`/environment issue rather than a functional one. Flagging it only because it may be worth a look on its own.

## What I have not tested

- **Anything other than macOS/arm64.** No Linux, Windows or Intel coverage at all. Nothing in either commit is architecture-specific — portable C++, no intrinsics, no platform calls — but untested is untested, and it's the one gap I can't close from here.

## Provenance

Both are ported from **ElMech's** work in schwung-jv880 (commit `3ef2204`, PR #5 there), which is also MAME-licensed, and they're credited as co-author on each commit. The ideas and original implementations are theirs; the port to this tree's shape and the measurements here are mine.

Their PR also included a third optimisation, skipping the PCM voice pipeline for idle slots. I ported and validated it too, but **left it out**: on this firmware it measured only −0.2% to −0.7%, because most configured slots stay keyed while anything sounds and the SLEEP fast-forward already removes most of the surrounding cost. It carried the subtlest equivalence argument of the three for essentially no gain. Happy to send it separately if you want it.

## Reproducing this

Rebased onto `main` after #127 merged, and every measurement above was re-taken against that new baseline rather than carried over.

The third commit adds the two harness modes the numbers come from, so nothing here has to be taken on trust:

```
./tools/blockdrop/build.sh
./tools/blockdrop/blockdrop_test <rom-dir> --bench  48000 512 7   # timing + cycles
./tools/blockdrop/blockdrop_test <rom-dir> --stress 48000 512     # bit-exactness under load
./tools/blockdrop/blockdrop_test <rom-dir> --card <cache-file> drum 0   # rhythm set
JV880_SECS=180 ./tools/blockdrop/blockdrop_test <rom-dir> --stress 48000 512
```

Run either against this branch and against `main` and compare the reported hash.

Written with Claude's help, as mentioned on Discord.
